### PR TITLE
Fix event ID matching for processed leads

### DIFF
--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -76,8 +76,8 @@ const NewLeads: FC<Props> = ({
       <Stack spacing={2}>
         {leads.slice(0, visibleCount).map(({ lead_id, business_id, processed_at }) => {
           const detail = leadDetails[lead_id] || {};
-          const matchedEvent = events.find(
-            e => e.payload?.data?.updates?.[0]?.lead_id === lead_id
+          const matchedEvent = events.find(e =>
+            e.payload?.data?.updates?.some(u => u.lead_id === lead_id)
           );
           const eventId = matchedEvent?.id;
           const isNew = !viewedLeads.has(lead_id);


### PR DESCRIPTION
## Summary
- fix matching events to processed leads by scanning all updates

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a57b2dfb8832dbe338f15e717dd86