### PR TITLE
Fix proxy paths for leads API

### DIFF
--- a/frontend/src/Events/EventDetail.tsx
+++ b/frontend/src/Events/EventDetail.tsx
@@ -36,7 +36,7 @@ const EventDetail: FC = () => {
 
   const fetchDetails = useCallback(async (lead: string) => {
     const { data } = await axios.get<{ events: DetailedEvent[] }>(
-      `/yelp/leads/${encodeURIComponent(lead)}/events/`,
+      `/api/yelp/leads/${encodeURIComponent(lead)}/events/`,
       { params: { limit: 20 } }
     );
     setEventsDetail(data.events);
@@ -45,7 +45,7 @@ const EventDetail: FC = () => {
   const fetchLeadDetail = useCallback(async (lead: string) => {
     try {
       const { data } = await axios.get<LeadDetail>(
-        `/yelp/leads/${encodeURIComponent(lead)}/`
+        `/api/yelp/leads/${encodeURIComponent(lead)}/`
       );
       setLeadDetail(data);
     } catch {
@@ -56,7 +56,7 @@ const EventDetail: FC = () => {
   const fetchScheduled = useCallback(async () => {
     if (!leadId) return;
     const { data } = await axios.get<ScheduledMessage[]>(
-      `/yelp/leads/${leadId}/scheduled_messages/`
+      `/api/yelp/leads/${leadId}/scheduled_messages/`
     );
     setScheduled(data);
   }, [leadId]);
@@ -64,7 +64,7 @@ const EventDetail: FC = () => {
   const fetchHistory = useCallback(async () => {
     if (!leadId) return;
     const { data } = await axios.get<MessageHistory[]>(
-      `/yelp/leads/${leadId}/scheduled_messages/history/`
+      `/api/yelp/leads/${leadId}/scheduled_messages/history/`
     );
     setHistory(data);
   }, [leadId]);

--- a/frontend/src/Events/InstantMessageSection.tsx
+++ b/frontend/src/Events/InstantMessageSection.tsx
@@ -48,7 +48,7 @@ const InstantMessageSection: FC<InstantSectionProps> = ({
     setSending(true);
     try {
       await axios.post(
-        `/yelp/leads/${encodeURIComponent(leadId)}/events/`,
+        `/api/yelp/leads/${encodeURIComponent(leadId)}/events/`,
         { request_content: msg, request_type: 'TEXT' }
       );
       setSuccess(true);

--- a/frontend/src/Events/ScheduledMessagesSection.tsx
+++ b/frontend/src/Events/ScheduledMessagesSection.tsx
@@ -94,7 +94,7 @@ const ScheduledMessagesSection: FC<ScheduledSectionProps> = ({
     setError(null);
     try {
       await axios.post(
-        `/yelp/leads/${leadId}/scheduled_messages/`,
+        `/api/yelp/leads/${leadId}/scheduled_messages/`,
         { content: newContent, interval_minutes: minutesToSend },
         {}
       );
@@ -124,7 +124,7 @@ const ScheduledMessagesSection: FC<ScheduledSectionProps> = ({
     if (!selectedMessage) return;
     try {
       await axios.patch(
-        `/yelp/leads/${leadId}/scheduled_messages/${selectedMessage.id}/`,
+        `/api/yelp/leads/${leadId}/scheduled_messages/${selectedMessage.id}/`,
         { active: false },
         {}
       );

--- a/frontend/src/Events/types.ts
+++ b/frontend/src/Events/types.ts
@@ -57,7 +57,7 @@ export interface MessageHistory {
   error?: string;
 }
 
-// Для LeadDetail (повна відповідь /yelp/leads/:id)
+// Для LeadDetail (повна відповідь /api/yelp/leads/:id)
 export interface SurveyAnswer {
   question_text: string;
   answer_text: string[];

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -61,7 +61,7 @@ const NewLeads: FC<Props> = ({
       for (const lid of toFetch) {
         try {
           const { data } = await axios.get<{ events: any[] }>(
-            `/yelp/leads/${encodeURIComponent(lid)}/events/`,
+            `/api/yelp/leads/${encodeURIComponent(lid)}/events/`,
             { params: { limit: 1 } }
           );
           const ev = data.events?.[0];

--- a/frontend/src/YelpAuth.tsx
+++ b/frontend/src/YelpAuth.tsx
@@ -5,7 +5,7 @@ import { Container, Box, Typography, Button, Paper } from '@mui/material';
 const YelpAuth: FC = () => {
   const handleYelpLogin = async () => {
     try {
-      const res = await axios.get<{ authorization_url: string }>('/yelp/auth/init/');
+      const res = await axios.get<{ authorization_url: string }>('/api/yelp/auth/init/');
       window.location.href = res.data.authorization_url;
     } catch {
       window.alert('Не вдалося почати авторизацію Yelp.');


### PR DESCRIPTION
## Summary
- update frontend to call `/api/yelp/...` endpoints

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `python backend/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685a62486830832d9be6e87b9209150a