### PR TITLE
Fix double API prefix

### DIFF
--- a/frontend/src/ClientDetails/ClientDetails.tsx
+++ b/frontend/src/ClientDetails/ClientDetails.tsx
@@ -249,7 +249,7 @@ const LeadDetail: FC = () => {
                     }}
                   >
                     {atts.map((att: any) => {
-                      const proxyUrl = `/api/yelp/leads/${leadId}/attachments/${encodeURIComponent(att.id)}/`;
+                      const proxyUrl = `/yelp/leads/${leadId}/attachments/${encodeURIComponent(att.id)}/`;
                       return (
                         <MuiCard variant="outlined" key={att.id}>
                           <a href={att.url} target="_blank" rel="noreferrer">

--- a/frontend/src/Events/EventDetail.tsx
+++ b/frontend/src/Events/EventDetail.tsx
@@ -36,7 +36,7 @@ const EventDetail: FC = () => {
 
   const fetchDetails = useCallback(async (lead: string) => {
     const { data } = await axios.get<{ events: DetailedEvent[] }>(
-      `/api/yelp/leads/${encodeURIComponent(lead)}/events/`,
+      `/yelp/leads/${encodeURIComponent(lead)}/events/`,
       { params: { limit: 20 } }
     );
     setEventsDetail(data.events);
@@ -45,7 +45,7 @@ const EventDetail: FC = () => {
   const fetchLeadDetail = useCallback(async (lead: string) => {
     try {
       const { data } = await axios.get<LeadDetail>(
-        `/api/yelp/leads/${encodeURIComponent(lead)}/`
+        `/yelp/leads/${encodeURIComponent(lead)}/`
       );
       setLeadDetail(data);
     } catch {
@@ -56,7 +56,7 @@ const EventDetail: FC = () => {
   const fetchScheduled = useCallback(async () => {
     if (!leadId) return;
     const { data } = await axios.get<ScheduledMessage[]>(
-      `/api/yelp/leads/${leadId}/scheduled_messages/`
+      `/yelp/leads/${leadId}/scheduled_messages/`
     );
     setScheduled(data);
   }, [leadId]);
@@ -64,7 +64,7 @@ const EventDetail: FC = () => {
   const fetchHistory = useCallback(async () => {
     if (!leadId) return;
     const { data } = await axios.get<MessageHistory[]>(
-      `/api/yelp/leads/${leadId}/scheduled_messages/history/`
+      `/yelp/leads/${leadId}/scheduled_messages/history/`
     );
     setHistory(data);
   }, [leadId]);

--- a/frontend/src/Events/InstantMessageSection.tsx
+++ b/frontend/src/Events/InstantMessageSection.tsx
@@ -48,7 +48,7 @@ const InstantMessageSection: FC<InstantSectionProps> = ({
     setSending(true);
     try {
       await axios.post(
-        `/api/yelp/leads/${encodeURIComponent(leadId)}/events/`,
+        `/yelp/leads/${encodeURIComponent(leadId)}/events/`,
         { request_content: msg, request_type: 'TEXT' }
       );
       setSuccess(true);

--- a/frontend/src/Events/ScheduledMessagesSection.tsx
+++ b/frontend/src/Events/ScheduledMessagesSection.tsx
@@ -94,7 +94,7 @@ const ScheduledMessagesSection: FC<ScheduledSectionProps> = ({
     setError(null);
     try {
       await axios.post(
-        `/api/yelp/leads/${leadId}/scheduled_messages/`,
+        `/yelp/leads/${leadId}/scheduled_messages/`,
         { content: newContent, interval_minutes: minutesToSend },
         {}
       );
@@ -124,7 +124,7 @@ const ScheduledMessagesSection: FC<ScheduledSectionProps> = ({
     if (!selectedMessage) return;
     try {
       await axios.patch(
-        `/api/yelp/leads/${leadId}/scheduled_messages/${selectedMessage.id}/`,
+        `/yelp/leads/${leadId}/scheduled_messages/${selectedMessage.id}/`,
         { active: false },
         {}
       );

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -61,7 +61,7 @@ const NewLeads: FC<Props> = ({
       for (const lid of toFetch) {
         try {
           const { data } = await axios.get<{ events: any[] }>(
-            `/api/yelp/leads/${encodeURIComponent(lid)}/events/`,
+            `/yelp/leads/${encodeURIComponent(lid)}/events/`,
             { params: { limit: 1 } }
           );
           const ev = data.events?.[0];

--- a/frontend/src/YelpAuth.tsx
+++ b/frontend/src/YelpAuth.tsx
@@ -5,7 +5,7 @@ import { Container, Box, Typography, Button, Paper } from '@mui/material';
 const YelpAuth: FC = () => {
   const handleYelpLogin = async () => {
     try {
-      const res = await axios.get<{ authorization_url: string }>('/api/yelp/auth/init/');
+      const res = await axios.get<{ authorization_url: string }>('/yelp/auth/init/');
       window.location.href = res.data.authorization_url;
     } catch {
       window.alert('Не вдалося почати авторизацію Yelp.');


### PR DESCRIPTION
## Summary
- remove extra `/api` prefix from API calls

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a64176e54832d8bff0d8cceea2450