### PR TITLE
Fix event id handling

### DIFF
--- a/frontend/src/Events/types.ts
+++ b/frontend/src/Events/types.ts
@@ -8,7 +8,7 @@ export interface PayloadUpdate {
 
 // Початковий Event з /events
 export interface EventItem {
-  id: number;
+  id: number | string;
   created_at: string;
   payload?: {
     data?: {

--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -186,7 +186,7 @@ const EventsPage: FC = () => {
       setEvents(prev => [...prev, ...data.results]);
       setEventsNextUrl(data.next);
       if (data.results.length) {
-        const maxId = Math.max(...data.results.map(e => e.id));
+        const maxId = Math.max(...data.results.map(e => Number(e.id)));
         lastEventIdRef.current = Math.max(lastEventIdRef.current || 0, maxId);
       }
     } catch {
@@ -204,8 +204,8 @@ const EventsPage: FC = () => {
       const { data } = await axios.get<EventItem[]>(url);
       console.log('[pollEvents] received', data.length, 'events');
       if (data.length) {
-        const sorted = [...data].sort((a, b) => a.id - b.id);
-        const maxId = sorted[sorted.length - 1].id;
+        const sorted = [...data].sort((a, b) => Number(a.id) - Number(b.id));
+        const maxId = Number(sorted[sorted.length - 1].id);
         setEvents(prev => [...sorted, ...prev]);
         setTotalEventsCount(prev => prev + data.length);
         lastEventIdRef.current = Math.max(lastEventIdRef.current || 0, maxId);
@@ -255,7 +255,7 @@ const EventsPage: FC = () => {
 
   const newEvents = filteredEvents
     .filter(e => e.payload?.data?.updates?.[0]?.event_type === 'NEW_EVENT')
-    .sort((a, b) => b.id - a.id);
+    .sort((a, b) => Number(b.id) - Number(a.id));
   const unreadEventsCount = Math.max(0, totalEventsCount - viewedEvents.size);
 
   return (

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -36,7 +36,7 @@ const NewLeads: FC<Props> = ({
   const navigate = useNavigate();
 
   const [viewedLeads, setViewedLeads] = useState<Set<string>>(new Set());
-  const [fetchedEvents, setFetchedEvents] = useState<Record<string, number>>({});
+  const [fetchedEvents, setFetchedEvents] = useState<Record<string, string>>({});
 
   useEffect(() => {
     const stored = localStorage.getItem('viewedLeads');
@@ -72,8 +72,8 @@ const NewLeads: FC<Props> = ({
             lid
           );
           const ev = data.events?.[0];
-          if (ev && typeof ev.id === 'number') {
-            setFetchedEvents(prev => ({ ...prev, [lid]: ev.id }));
+          if (ev && ev.id) {
+            setFetchedEvents(prev => ({ ...prev, [lid]: String(ev.id) }));
           }
         } catch (err) {
           console.error('[lead events] failed for', lid, err);
@@ -95,7 +95,7 @@ const NewLeads: FC<Props> = ({
     navigate(`/leads/${encodeURIComponent(lead_id)}`);
   };
 
-  const handleViewEvent = (lead_id: string, eventId: number) => {
+  const handleViewEvent = (lead_id: string, eventId: string) => {
     markAsViewed(lead_id);
     navigate(`/events/${eventId}`);
   };
@@ -117,7 +117,7 @@ const NewLeads: FC<Props> = ({
             e.payload?.data?.updates?.some(u => u.lead_id === lead_id)
           );
           const rawEventId = matchedEvent?.id ?? fetchedEvents[lead_id];
-          const eventId = typeof rawEventId === 'number' ? rawEventId : undefined;
+          const eventId = rawEventId ? String(rawEventId) : undefined;
           const isNew = !viewedLeads.has(lead_id);
 
           return (

--- a/frontend/src/EventsPage/types.ts
+++ b/frontend/src/EventsPage/types.ts
@@ -12,7 +12,7 @@ export interface PayloadUpdate {
 }
 
 export interface EventItem {
-  id: number;
+  id: number | string;
   created_at: string;
   payload: {
     data: {


### PR DESCRIPTION
## Summary
- allow events to have string IDs
- fetch Yelp events as strings in new leads UI
- compare and sort events numerically regardless of ID type

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `npx --yes tsc --project frontend/tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a6ded2be8832d9a8612a837319508