### PR TITLE
Increase API pagination size

### DIFF
--- a/backend/webhooks/pagination.py
+++ b/backend/webhooks/pagination.py
@@ -1,4 +1,10 @@
 from rest_framework.pagination import PageNumberPagination
 
 class FivePerPagePagination(PageNumberPagination):
-    page_size = 5
+    """Default pagination size for API responses."""
+
+    # Increase page size from 5 to 20 so that API endpoints return
+    # larger result sets per request. This helps reduce the number of
+    # requests required on the frontend while still keeping the data
+    # set manageable.
+    page_size = 20


### PR DESCRIPTION
## Summary
- expand `FivePerPagePagination` from 5 to 20 items per page

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7ef1d2c4832dba72133c02f1b40d