### PR TITLE
Adjust events pagination and loading

### DIFF
--- a/backend/webhooks/pagination.py
+++ b/backend/webhooks/pagination.py
@@ -3,8 +3,6 @@ from rest_framework.pagination import PageNumberPagination
 class FivePerPagePagination(PageNumberPagination):
     """Default pagination size for API responses."""
 
-    # Increase page size from 5 to 20 so that API endpoints return
-    # larger result sets per request. This helps reduce the number of
-    # requests required on the frontend while still keeping the data
-    # set manageable.
-    page_size = 20
+    # Return smaller result sets to keep the list pages lightweight.
+    # Frontend is expected to request additional pages as needed.
+    page_size = 5

--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -75,6 +75,29 @@ const NewEvents: FC<Props> = ({
           const detail = leadDetails[upd.lead_id];
           const isNew = !viewedEvents.has(String(e.id));
 
+          if (!eventIds[e.id]) {
+            return (
+              <Paper
+                key={e.id}
+                elevation={2}
+                sx={{
+                  p: 2,
+                  backgroundColor: isNew
+                    ? theme.palette.action.hover
+                    : theme.palette.background.paper,
+                  borderLeft: isNew
+                    ? `4px solid ${theme.palette.primary.main}`
+                    : 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Typography>Loading...</Typography>
+              </Paper>
+            );
+          }
+
           return (
             <Paper
               key={e.id}
@@ -90,7 +113,7 @@ const NewEvents: FC<Props> = ({
               }}
             >
               <Stack spacing={1}>
-                <Typography variant="h6">Event #{eventIds[e.id] || '...'}</Typography>
+                <Typography variant="h6">Event #{eventIds[e.id]}</Typography>
                 <Typography variant="body2" color="text.secondary">
                   {new Date(e.created_at).toLocaleString()}
                 </Typography>
@@ -129,18 +152,14 @@ const NewEvents: FC<Props> = ({
                 <Divider />
 
                 <Box>
-                  {eventIds[e.id] ? (
-                    <Button
-                      component={RouterLink}
-                      to={`/events/${eventIds[e.id]}`}
-                      variant="outlined"
-                      size="small"
-                    >
-                      View Full Details
-                    </Button>
-                  ) : (
-                    <CircularProgress size={20} />
-                  )}
+                  <Button
+                    component={RouterLink}
+                    to={`/events/${eventIds[e.id]}`}
+                    variant="outlined"
+                    size="small"
+                  >
+                    View Full Details
+                  </Button>
                 </Box>
               </Stack>
             </Paper>


### PR DESCRIPTION
## Summary
- set default API pagination size to 5
- show full card as `Loading...` until event details are loaded

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b8ed140832d8d432755231b709c