### PR TITLE
Store business hours with timezone

### DIFF
--- a/backend/webhooks/migrations/0023_yelpbusiness_hours.py
+++ b/backend/webhooks/migrations/0023_yelpbusiness_hours.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0022_yelpbusiness_time_zone'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='yelpbusiness',
+            name='open_days',
+            field=models.CharField(max_length=128, blank=True),
+        ),
+        migrations.AddField(
+            model_name='yelpbusiness',
+            name='open_hours',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -45,6 +45,8 @@ class YelpBusiness(models.Model):
     name = models.CharField(max_length=255)
     location = models.CharField(max_length=255, blank=True)
     time_zone = models.CharField(max_length=64, blank=True)
+    open_days = models.CharField(max_length=128, blank=True)
+    open_hours = models.TextField(blank=True)
     details = models.JSONField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -221,7 +221,15 @@ class LeadScheduledMessageHistorySerializer(serializers.ModelSerializer):
 class YelpBusinessSerializer(serializers.ModelSerializer):
     class Meta:
         model = YelpBusiness
-        fields = ["business_id", "name", "location", "time_zone", "details"]
+        fields = [
+            "business_id",
+            "name",
+            "location",
+            "time_zone",
+            "open_days",
+            "open_hours",
+            "details",
+        ]
         read_only_fields = fields
 
 


### PR DESCRIPTION
## Summary
- add `open_days` and `open_hours` fields to `YelpBusiness`
- add migration for these fields
- compute days and hours when updating business info
- expose new fields via serializer

## Testing
- `python -m py_compile webhooks/models.py webhooks/oauth_views.py webhooks/serializers.py`
- `python -m compileall -q webhooks`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a90ab6bf8832dbb4bb37cbb0a8a0c