### PR TITLE
Fix timezone handling

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -77,7 +77,8 @@ CELERY_RESULT_BACKEND  = "redis://localhost:6379/1"
 CELERY_ACCEPT_CONTENT  = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
-CELERY_TIMEZONE = "Europe/Kyiv"
+# Use UTC for Celery to avoid timezone offsets when scheduling tasks
+CELERY_TIMEZONE = "UTC"
 
 
 # Application definition

--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -384,7 +384,8 @@ const AutoResponseSettings: FC = () => {
                     let localTime = '';
                     if (tz) {
                       const ms = Date.now() + t.delay * 1000;
-                      localTime = new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
+                      const fmt = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
+                      localTime = fmt.format(ms);
                     }
                     return (
                       <ListItem
@@ -463,7 +464,8 @@ const AutoResponseSettings: FC = () => {
                     if (!tz) return null;
                     const secs = newDelayValue * TIME_UNITS.find(u => u.value === newDelayUnit)!.factor;
                     const ms = Date.now() + secs * 1000;
-                    const local = new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
+                    const fmt = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
+                    const local = fmt.format(ms);
                     return (
                       <Typography variant="body2" sx={{ ml:1 }}>
                         {local}


### PR DESCRIPTION
## Summary
- switch Celery to UTC so scheduled tasks use consistent timezone
- use Intl.DateTimeFormat for follow-up template time previews

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a9f35fb18832d9c7ef3b08680525c