### PR TITLE
Enhance Celery logging with timezone info

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -1,8 +1,42 @@
 import os
+import logging
+from datetime import datetime
+
 from celery import Celery
+from celery.signals import before_task_publish
+from django.utils import timezone
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 
 app = Celery('config')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
+
+logger = logging.getLogger(__name__)
+
+
+@before_task_publish.connect
+def log_task_schedule(sender=None, headers=None, **kwargs):
+    """Log when a task is scheduled to run including timezone."""
+    eta = headers.get("eta") if headers else None
+    tz = timezone.get_current_timezone()
+    if eta:
+        try:
+            eta_dt = datetime.fromisoformat(eta)
+        except ValueError:
+            # Fallback if fromisoformat fails
+            eta_dt = datetime.strptime(eta, "%Y-%m-%dT%H:%M:%S.%f%z")
+        if timezone.is_naive(eta_dt):
+            eta_dt = timezone.make_aware(eta_dt, timezone.utc)
+        run_time = timezone.localtime(eta_dt, tz)
+        logger.info(
+            "[CELERY] %s scheduled for %s", sender,
+            run_time.strftime("%Y-%m-%d %H:%M:%S %Z"),
+        )
+    else:
+        now = timezone.localtime(timezone.now(), tz)
+        logger.info(
+            "[CELERY] %s scheduled for immediate execution at %s",
+            sender,
+            now.strftime("%Y-%m-%d %H:%M:%S %Z"),
+        )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -42,8 +42,9 @@ LOGGING = {
     'disable_existing_loggers': False,   # не вимикати логери Django
     'formatters': {
         'simple': {
-            'format': '[{levelname}] {name}:{lineno} {message}',
+            'format': '{asctime} [{levelname}] {name}:{lineno} {message}',
             'style': '{',
+            'datefmt': '%Y-%m-%d %H:%M:%S %Z',
         },
     },
     'handlers': {


### PR DESCRIPTION
## Summary
- log scheduled time and timezone when Celery publishes tasks
- include timestamp with timezone in default logging format

## Testing
- `python -m py_compile backend/config/celery.py backend/config/settings.py`
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685aad28e438832db64eec7fbd175d69