### PR TITLE
Add message task log view with business context

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -33,6 +33,7 @@ def log_task_schedule(sender=None, headers=None, **kwargs):
     task_id = headers.get("id") if headers else None
     args = kwargs.get("body", [])[0] if kwargs.get("body") else None
     kargs = kwargs.get("body", [])[1] if kwargs.get("body") else None
+    business_id = headers.get("business_id") if headers else None
     if eta:
         try:
             eta_dt = datetime.fromisoformat(eta)
@@ -66,6 +67,7 @@ def log_task_schedule(sender=None, headers=None, **kwargs):
                     "kwargs": kargs,
                     "eta": schedule_time,
                     "status": "SCHEDULED",
+                    "business_id": business_id,
                 },
             )
 

--- a/backend/webhooks/task_views.py
+++ b/backend/webhooks/task_views.py
@@ -3,7 +3,7 @@ from django_filters.rest_framework import DjangoFilterBackend, FilterSet, filter
 from rest_framework import generics
 
 from .models import CeleryTaskLog
-from .serializers import CeleryTaskLogSerializer
+from .serializers import CeleryTaskLogSerializer, MessageTaskSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -37,4 +37,23 @@ class TaskLogListView(generics.ListAPIView):
         if start:
             qs = qs.filter(finished_at__gte=start)
         return qs
+
+
+class MessageTaskListView(generics.ListAPIView):
+    """Simplified list of executed message tasks."""
+
+    serializer_class = MessageTaskSerializer
+
+    def get_queryset(self):
+        return (
+            CeleryTaskLog.objects.filter(
+                name__in=[
+                    "send_follow_up",
+                    "send_scheduled_message",
+                    "send_lead_scheduled_message",
+                ],
+                finished_at__isnull=False,
+            )
+            .order_by("-finished_at")
+        )
 

--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -53,9 +53,15 @@ def send_due_scheduled_messages():
     due_list = ScheduledMessage.objects.filter(active=True, next_run__lte=now)
 
     for sched in due_list:
+        biz_id = (
+            LeadDetail.objects.filter(lead_id=sched.lead_id)
+            .values_list("business_id", flat=True)
+            .first()
+        )
         send_scheduled_message.apply_async(
             args=[sched.lead_id, sched.id],
-            countdown=0
+            headers={"business_id": biz_id},
+            countdown=0,
         )
 
 
@@ -121,9 +127,15 @@ def send_due_lead_scheduled_messages():
     now = timezone.now()
     due = LeadScheduledMessage.objects.filter(active=True, next_run__lte=now)
     for msg in due:
+        biz_id = (
+            LeadDetail.objects.filter(lead_id=msg.lead_id)
+            .values_list("business_id", flat=True)
+            .first()
+        )
         send_lead_scheduled_message.apply_async(
             args=[msg.id],
-            countdown=0
+            headers={"business_id": biz_id},
+            countdown=0,
         )
 
 

--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -9,7 +9,7 @@ from .views import (
     BusinessListView, BusinessLeadsView, BusinessEventsView,
     YelpTokenListView,
 )
-from .task_views import TaskLogListView
+from .task_views import TaskLogListView, MessageTaskListView
 
 urlpatterns = [
     path('webhook/', WebhookView.as_view(), name='webhook'),
@@ -82,4 +82,5 @@ urlpatterns = [
     path('follow-up-templates/<int:pk>/', FollowUpTemplateDestroyView.as_view(), name='followup-destroy'),
     path('tokens/', YelpTokenListView.as_view(), name='token-list'),
     path('tasks/', TaskLogListView.as_view(), name='task-log-list'),
+    path('message_tasks/', MessageTaskListView.as_view(), name='message-task-list'),
 ]

--- a/frontend/src/TaskLogs.tsx
+++ b/frontend/src/TaskLogs.tsx
@@ -3,8 +3,6 @@ import axios from 'axios';
 import {
   Container,
   Box,
-  Tabs,
-  Tab,
   Typography,
   Table,
   TableHead,
@@ -14,91 +12,55 @@ import {
   CircularProgress,
 } from '@mui/material';
 
-type TaskLog = {
-  task_id: string;
-  name: string;
-  args: any;
-  kwargs: any;
-  eta: string | null;
-  started_at: string | null;
-  finished_at: string | null;
-  status: string;
-  result: string | null;
-  business_id: string | null;
+type MessageTask = {
+  executed_at: string;
+  text: string;
+  business_name: string | null;
+  task_type: string;
 };
 
 const TaskLogs: React.FC = () => {
-  const [tab, setTab] = useState(0);
-  const [scheduled, setScheduled] = useState<TaskLog[]>([]);
-  const [executed, setExecuted] = useState<TaskLog[]>([]);
+  const [rows, setRows] = useState<MessageTask[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const load = () => {
-    setLoading(true);
-    axios
-      .get<TaskLog[]>('/tasks/?status=SCHEDULED')
-      .then(res => setScheduled(res.data))
-      .catch(() => setScheduled([]));
-    axios
-      .get<TaskLog[]>('/tasks/?status=SUCCESS&status=FAILURE&status=STARTED')
-      .then(res => setExecuted(res.data))
-      .catch(() => setExecuted([]))
-      .finally(() => setLoading(false));
-  };
-
   useEffect(() => {
-    load();
+    axios
+      .get<MessageTask[]>('/message_tasks/')
+      .then(res => setRows(res.data))
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false));
   }, []);
-
-  const renderTable = (rows: TaskLog[]) => (
-    <Table size="small">
-      <TableHead>
-        <TableRow>
-          <TableCell>ID</TableCell>
-          <TableCell>Name</TableCell>
-          <TableCell>ETA</TableCell>
-          <TableCell>Started</TableCell>
-          <TableCell>Finished</TableCell>
-          <TableCell>Status</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {rows.map(r => (
-          <TableRow key={r.task_id}>
-            <TableCell>{r.task_id}</TableCell>
-            <TableCell>{r.name}</TableCell>
-            <TableCell>{r.eta ? new Date(r.eta).toLocaleString() : ''}</TableCell>
-            <TableCell>
-              {r.started_at ? new Date(r.started_at).toLocaleString() : ''}
-            </TableCell>
-            <TableCell>
-              {r.finished_at ? new Date(r.finished_at).toLocaleString() : ''}
-            </TableCell>
-            <TableCell>{r.status}</TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  );
 
   return (
     <Container sx={{ mt: 4 }}>
       <Typography variant="h4" gutterBottom>
-        Celery Tasks
+        Message Tasks
       </Typography>
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
           <CircularProgress />
         </Box>
       ) : (
-        <>
-          <Tabs value={tab} onChange={(_, v) => setTab(v)}>
-            <Tab label="Заплановані" />
-            <Tab label="Виконані" />
-          </Tabs>
-          <Box hidden={tab !== 0}>{renderTable(scheduled)}</Box>
-          <Box hidden={tab !== 1}>{renderTable(executed)}</Box>
-        </>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Time</TableCell>
+              <TableCell>Text</TableCell>
+              <TableCell>Business</TableCell>
+              <TableCell>Type</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((r, idx) => (
+              <TableRow key={idx}>
+                <TableCell>{new Date(r.executed_at).toLocaleString()}</TableCell>
+                <TableCell>{r.text}</TableCell>
+                <TableCell>{r.business_name || ''}</TableCell>
+                <TableCell>{r.task_type}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       )}
     </Container>
   );


### PR DESCRIPTION
## Summary
- propagate `business_id` through Celery task scheduling
- save `business_id` in CeleryTaskLog when tasks are queued
- expose `/message_tasks/` endpoint returning simplified message history
- show message task table in frontend

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685baba5cd04832db69331aeb41763e7