### PR TITLE
Fix API base URL

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,7 +50,7 @@ const theme = createTheme({
 // Базовий URL для API
 axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL
   ? `${process.env.REACT_APP_API_BASE_URL}/api`
-  : 'http://localhost:8000/api';
+  : '/api';
 
 
 // ---------------------------------------------


### PR DESCRIPTION
## Summary
- default axios base URL to '/api' instead of localhost

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baf7df038832d8b304f507b629a83