### PR TITLE
fix: revert API base url

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,7 +50,7 @@ const theme = createTheme({
 // Базовий URL для API
 axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL
   ? `${process.env.REACT_APP_API_BASE_URL}/api`
-  : '/api';
+  : 'http://localhost:8000/api';
 
 
 // ---------------------------------------------


### PR DESCRIPTION
## Summary
- revert axios default base URL back to `http://localhost:8000/api`

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb10dcd34832da4fd60a414b3ea27