### PR TITLE
Update follow-up template hours

### DIFF
--- a/backend/webhooks/utils.py
+++ b/backend/webhooks/utils.py
@@ -103,8 +103,8 @@ def adjust_due_time(base_dt, tz_name: str | None, start: time, end: time):
         return base_dt
     tz = ZoneInfo(tz_name)
     local = base_dt.astimezone(tz)
-    open_dt = local.replace(hour=start.hour, minute=start.minute, second=0, microsecond=0)
-    close_dt = local.replace(hour=end.hour, minute=end.minute, second=0, microsecond=0)
+    open_dt = local.replace(hour=start.hour, minute=start.minute, second=start.second, microsecond=0)
+    close_dt = local.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
     if close_dt <= open_dt:
         close_dt += timedelta(days=1)
     if local < open_dt:

--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -85,8 +85,8 @@ const AutoResponseSettings: FC = () => {
   const [newDelayHours, setNewDelayHours] = useState(1);
   const [newDelayMinutes, setNewDelayMinutes] = useState(0);
   const [newDelaySeconds, setNewDelaySeconds] = useState(0);
-  const [newOpenFrom, setNewOpenFrom] = useState('08:00');
-  const [newOpenTo, setNewOpenTo] = useState('20:00');
+  const [newOpenFrom, setNewOpenFrom] = useState('08:00:00');
+  const [newOpenTo, setNewOpenTo] = useState('20:00:00');
 
   // UI state
   const [loading, setLoading] = useState(true);
@@ -270,7 +270,7 @@ const AutoResponseSettings: FC = () => {
   };
 
   return (
-    <Container maxWidth={false} sx={{ mt:4, mb:4, maxWidth: 900, mx: 'auto' }}>
+    <Container maxWidth={false} sx={{ mt:4, mb:4, maxWidth: 1000, mx: 'auto' }}>
       <Box sx={{ mb: 2 }}>
         <Select
           value={selectedBusiness}
@@ -460,7 +460,7 @@ const AutoResponseSettings: FC = () => {
                     placeholder="New follow-up template..."
                   />
                 </Box>
-                <Stack direction="row" spacing={1} alignItems="center">
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
                   <TextField
                     label="Days"
                     type="number"
@@ -493,34 +493,41 @@ const AutoResponseSettings: FC = () => {
                     value={newDelaySeconds}
                     onChange={e => setNewDelaySeconds(Number(e.target.value))}
                   />
-                  <TextField
-                    label="From"
-                    type="time"
-                    value={newOpenFrom}
-                    onChange={e => setNewOpenFrom(e.target.value)}
-                    size="small"
-                  />
-                  <TextField
-                    label="To"
-                    type="time"
-                    value={newOpenTo}
-                    onChange={e => setNewOpenTo(e.target.value)}
-                    size="small"
-                  />
-                  {selectedBusiness && (() => {
-                    const biz = businesses.find(b => b.business_id === selectedBusiness);
-                    const tz = biz?.time_zone;
-                    if (!tz) return null;
-                    const fmt = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', timeZone: tz });
-                    const local = fmt.format(Date.now());
-                    return (
-                      <Typography variant="body2" sx={{ ml:1 }}>
-                        {local}
-                      </Typography>
-                    );
-                  })()}
                 </Stack>
-                <Button onClick={handleAddTemplate} disabled={tplLoading}>
+                <Box sx={{ mt: 1 }}>
+                  <Typography variant="body2" gutterBottom>Години роботи</Typography>
+                  <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                    <TextField
+                      label="From"
+                      type="time"
+                      inputProps={{ step: 1 }}
+                      value={newOpenFrom}
+                      onChange={e => setNewOpenFrom(e.target.value)}
+                      size="small"
+                    />
+                    <TextField
+                      label="To"
+                      type="time"
+                      inputProps={{ step: 1 }}
+                      value={newOpenTo}
+                      onChange={e => setNewOpenTo(e.target.value)}
+                      size="small"
+                    />
+                    {selectedBusiness && (() => {
+                      const biz = businesses.find(b => b.business_id === selectedBusiness);
+                      const tz = biz?.time_zone;
+                      if (!tz) return null;
+                      const fmt = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: tz });
+                      const local = fmt.format(Date.now());
+                      return (
+                        <Typography variant="body2" sx={{ ml:1 }}>
+                          {local}
+                        </Typography>
+                      );
+                    })()}
+                  </Stack>
+                </Box>
+                <Button onClick={handleAddTemplate} disabled={tplLoading} sx={{ mt: 1 }}>
                   Add
                 </Button>
               </Stack>


### PR DESCRIPTION
## Summary
- tweak container width for settings page
- allow seconds in follow-up template working hours
- rearrange Additional Follow-up Template inputs
- preserve seconds in adjust_due_time

## Testing
- `npm test -- -w 0` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bbe176280832dbb9e3c52991798d5