### PR TITLE
Show executed tasks only

### DIFF
--- a/backend/webhooks/task_views.py
+++ b/backend/webhooks/task_views.py
@@ -18,9 +18,14 @@ class TaskLogFilterSet(FilterSet):
         fields = ["status", "business_id"]
 
     def filter_status(self, queryset, name, value):
-        values = self.data.getlist(name)
-        if values:
-            return queryset.filter(status__in=values)
+        """Support comma separated or repeated status params."""
+        raw_values = self.data.getlist(name)
+        statuses: list[str] = []
+        for v in raw_values:
+            if v:
+                statuses.extend(s.strip().upper() for s in v.split(",") if s.strip())
+        if statuses:
+            return queryset.filter(status__in=statuses)
         return queryset
 
 


### PR DESCRIPTION
## Summary
- filter `CeleryTaskLog` by comma separated status parameter
- show only succeeded/failed tasks in `/tasks` page

## Testing
- `pytest -q`
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcdbb13fc832db546c88d25867c26