### PR TITLE
Add scheduled tasks tab

### DIFF
--- a/frontend/src/TaskLogs.tsx
+++ b/frontend/src/TaskLogs.tsx
@@ -4,6 +4,8 @@ import {
   Container,
   Box,
   Typography,
+  Tabs,
+  Tab,
   Table,
   TableHead,
   TableRow,
@@ -28,16 +30,23 @@ interface Business {
 }
 
 const TaskLogs: React.FC = () => {
-  const [tasks, setTasks] = useState<TaskLog[]>([]);
+  const [completedTasks, setCompletedTasks] = useState<TaskLog[]>([]);
+  const [scheduledTasks, setScheduledTasks] = useState<TaskLog[]>([]);
   const [businesses, setBusinesses] = useState<Business[]>([]);
   const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<'completed' | 'scheduled'>('completed');
 
   useEffect(() => {
     axios
       .get<TaskLog[]>('/tasks/?status=success,failure')
-      .then(res => setTasks(res.data))
-      .catch(() => setTasks([]))
+      .then(res => setCompletedTasks(res.data))
+      .catch(() => setCompletedTasks([]))
       .finally(() => setLoading(false));
+
+    axios
+      .get<TaskLog[]>('/tasks/?status=scheduled')
+      .then(res => setScheduledTasks(res.data))
+      .catch(() => setScheduledTasks([]));
 
     axios
       .get<Business[]>('/businesses/')
@@ -77,11 +86,15 @@ const TaskLogs: React.FC = () => {
       <Typography variant="h4" gutterBottom>
         Celery Tasks
       </Typography>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="Completed" value="completed" />
+        <Tab label="Scheduled" value="scheduled" />
+      </Tabs>
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
           <CircularProgress />
         </Box>
-      ) : (
+      ) : tab === 'completed' ? (
         <Table size="small">
           <TableHead>
             <TableRow>
@@ -93,7 +106,7 @@ const TaskLogs: React.FC = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {tasks.map(t => (
+            {completedTasks.map(t => (
               <TableRow key={t.task_id}>
                 <TableCell>{getLeadId(t.args)}</TableCell>
                 <TableCell>{formatEta(t.eta, t.business_id)}</TableCell>
@@ -102,10 +115,36 @@ const TaskLogs: React.FC = () => {
                 <TableCell>{t.status === 'FAILURE' ? t.result || '' : ''}</TableCell>
               </TableRow>
             ))}
-            {tasks.length === 0 && (
+            {completedTasks.length === 0 && (
               <TableRow>
                 <TableCell colSpan={5} align="center">
                   Немає виконаних/з помилкою тасків
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Lead ID</TableCell>
+              <TableCell>Run Time</TableCell>
+              <TableCell>Message</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {scheduledTasks.map(t => (
+              <TableRow key={t.task_id}>
+                <TableCell>{getLeadId(t.args)}</TableCell>
+                <TableCell>{formatEta(t.eta, t.business_id)}</TableCell>
+                <TableCell>{getMessage(t.args)}</TableCell>
+              </TableRow>
+            ))}
+            {scheduledTasks.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={3} align="center">
+                  Немає запланованих тасків
                 </TableCell>
               </TableRow>
             )}


### PR DESCRIPTION
## Summary
- show Celery tasks with status `SCHEDULED`
- fetch scheduled tasks and display them on a new tab

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bd2193614832daa0c58b4cc9e2ac5