### PR TITLE
Fix import error in webhooks urls

### DIFF
--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -5,7 +5,7 @@ from .views import (
     YelpAuthInitView, YelpAuthCallbackView,
     AutoResponseSettingsView, LeadEventsProxyView, LeadIDsProxyView, LeadDetailProxyView, AttachmentProxyView, ScheduledMessageHistoryList,
     ScheduledMessageListCreate, ScheduledMessageDetail, ProcessedLeadListView, LeadDetailListAPIView,
-    LeadDetailRetrieveAPIView, LeadLastEventAPIView, LeadEventRetrieveAPIView, FollowUpTemplateListCreateView, FollowUpTemplateDestroyView,
+    LeadDetailRetrieveAPIView, LeadLastEventAPIView, LeadEventRetrieveAPIView, FollowUpTemplateListCreateView,
     BusinessListView, BusinessLeadsView, BusinessEventsView,
     YelpTokenListView,
 )


### PR DESCRIPTION
## Summary
- fix ImportError on startup by removing unused `FollowUpTemplateDestroyView` import in `webhooks/urls.py`

## Testing
- `python -m py_compile backend/webhooks/urls.py`
- `python backend/manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc67a010832d96187efed295e1de