### PR TITLE
Fix missing FollowUpTemplateDetailView import

### DIFF
--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -5,7 +5,8 @@ from .views import (
     YelpAuthInitView, YelpAuthCallbackView,
     AutoResponseSettingsView, LeadEventsProxyView, LeadIDsProxyView, LeadDetailProxyView, AttachmentProxyView, ScheduledMessageHistoryList,
     ScheduledMessageListCreate, ScheduledMessageDetail, ProcessedLeadListView, LeadDetailListAPIView,
-    LeadDetailRetrieveAPIView, LeadLastEventAPIView, LeadEventRetrieveAPIView, FollowUpTemplateListCreateView,
+    LeadDetailRetrieveAPIView, LeadLastEventAPIView, LeadEventRetrieveAPIView,
+    FollowUpTemplateListCreateView, FollowUpTemplateDetailView,
     BusinessListView, BusinessLeadsView, BusinessEventsView,
     YelpTokenListView,
 )


### PR DESCRIPTION
## Summary
- update URL config to import `FollowUpTemplateDetailView`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685bdda835a8832dbd301377ed1eef9a