### PR TITLE
Restore business time display

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -514,6 +514,18 @@ const AutoResponseSettings: FC = () => {
                       onChange={e => setNewOpenTo(e.target.value)}
                       size="small"
                     />
+                    {selectedBusiness && (() => {
+                      const biz = businesses.find(b => b.business_id === selectedBusiness);
+                      const tz = biz?.time_zone;
+                      if (!tz) return null;
+                      const fmt = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: tz });
+                      const local = fmt.format(Date.now());
+                      return (
+                        <Typography variant="body2" sx={{ ml:1 }}>
+                          {local}
+                        </Typography>
+                      );
+                    })()}
                   </Stack>
                 </Box>
                 <Button onClick={handleAddTemplate} disabled={tplLoading} sx={{ mt: 1 }}>


### PR DESCRIPTION
## Summary
- show the selected business's local time next to the business hours inputs

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685bee30b340832d97ad12c1c4edfb6e