### PR TITLE
Add /templates alias for settings

### DIFF
--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -43,6 +43,11 @@ urlpatterns = [
         name='auto-response-settings'
     ),
     path(
+        'templates/auto-response/',
+        AutoResponseSettingsView.as_view(),
+        name='templates-auto-response-settings'
+    ),
+    path(
         'yelp/leads/<str:lead_id>/events/',
         LeadEventsProxyView.as_view(),
         name='proxy-lead-events'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,6 @@ import ClientDetails from "./ClientDetails/ClientDetails";
 import BusinessSelector from "./BusinessSelector";
 import TokenStatus from "./TokenStatus";
 import TaskLogs from "./TaskLogs";
-import SettingsTemplates from "./SettingsTemplates";
 
 // A default theme for the application
 const theme = createTheme({
@@ -86,7 +85,7 @@ const App: React.FC = () => (
           <Route path="/settings" element={<AutoResponseSettings />} />
           <Route path="/tokens" element={<TokenStatus />} />
           <Route path="/tasks" element={<TaskLogs />} />
-          <Route path="/templates" element={<SettingsTemplates />} />
+          <Route path="/templates" element={<AutoResponseSettings />} />
         </Routes>
       </main>
     </Router>


### PR DESCRIPTION
## Summary
- map `/templates` to the AutoResponseSettings page
- expose backend `/templates/auto-response/` endpoint

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d37c43ef4832d958cf8120b0b12e1