### PR TITLE
Add follow up templates to template presets

### DIFF
--- a/backend/webhooks/migrations/0029_autoresponsesettingstemplate_followups.py
+++ b/backend/webhooks/migrations/0029_autoresponsesettingstemplate_followups.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webhooks', '0028_autoresponsesettingstemplate'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='autoresponsesettingstemplate',
+            name='follow_up_templates',
+            field=models.JSONField(default=list, blank=True, help_text='Serialized list of additional FollowUpTemplate objects'),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -279,6 +279,11 @@ class AutoResponseSettingsTemplate(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     data = models.JSONField(help_text="Serialized AutoResponseSettings data")
+    follow_up_templates = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Serialized list of additional FollowUpTemplate objects",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -346,5 +346,6 @@ class AutoResponseSettingsTemplateSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "data",
+            "follow_up_templates",
         ]
         read_only_fields = ["id"]


### PR DESCRIPTION
## Summary
- store additional follow-up templates on the backend
- expose the field via `AutoResponseSettingsTemplateSerializer`
- support editing follow-up templates in template editor UI
- show placeholder buttons for message fields

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fea1158832db2403489d704fcf1