### PR TITLE
Enable editing of follow-up templates

### DIFF
--- a/backend/webhooks/lead_views.py
+++ b/backend/webhooks/lead_views.py
@@ -26,6 +26,7 @@ from .serializers import (
     LeadEventSerializer,
     AutoResponseSettingsTemplateSerializer,
 )
+from .tasks import reschedule_follow_up_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,10 @@ class FollowUpTemplateDetailView(generics.RetrieveUpdateDestroyAPIView):
             if qs.exists():
                 return qs
         return FollowUpTemplate.objects.filter(business__isnull=True)
+
+    def perform_update(self, serializer):
+        instance = serializer.save()
+        reschedule_follow_up_tasks(instance)
 
 
 class AutoResponseSettingsTemplateListCreateView(generics.ListCreateAPIView):


### PR DESCRIPTION
## Summary
- allow editing follow‑up templates in settings page
- update backend to reschedule messages when a template changes

## Testing
- `python -m py_compile backend/webhooks/tasks.py backend/webhooks/lead_views.py`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d508dfe94832dbfb3ea6e7793e126