### PR TITLE
Fix follow-up templates sync

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -290,6 +290,17 @@ const AutoResponseSettings: FC = () => {
     loadTemplates(selectedBusiness || undefined);
   }, [selectedBusiness]);
 
+  // reload templates when other tabs modify them
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'followTemplateUpdated') {
+        loadTemplates(selectedBusiness || undefined);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [selectedBusiness]);
+
   // update local time for selected business
   useEffect(() => {
     let timer: ReturnType<typeof setInterval> | undefined;

--- a/frontend/src/SettingsTemplates.tsx
+++ b/frontend/src/SettingsTemplates.tsx
@@ -239,6 +239,25 @@ const SettingsTemplates: React.FC = () => {
       ...data,
       follow_up_templates: [...(data.follow_up_templates || []), tpl],
     });
+
+    // Persist template so it appears on the settings page
+    axios
+      .post('/follow-up-templates/', {
+        name: `Custom ${Date.now()}`,
+        template: newText,
+        delay: delaySecs,
+        open_from: newOpenFrom,
+        open_to: newOpenTo,
+        active: true,
+      })
+      .then(() => {
+        // notify other tabs/pages to refresh templates
+        localStorage.setItem('followTemplateUpdated', Date.now().toString());
+      })
+      .catch(() => {
+        // ignore error, template still stored locally in this dialog
+      });
+
     setNewText('');
     setNewDelayDays(0);
     setNewDelayHours(1);


### PR DESCRIPTION
## Summary
- persist new Additional Follow-up Templates when creating from `/templates`
- refresh `/settings` page templates when another tab adds one

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d57dd1e74832d80367e9276400a6f