### PR TITLE
Fix saving settings

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -445,7 +445,6 @@ const AutoResponseSettings: FC = () => {
 
   // save settings
   const handleSaveSettings = async () => {
-    if (settingsId === null) return;
     setLoading(true);
     const url = selectedBusiness ? `/settings/auto-response/?business_id=${selectedBusiness}` : '/settings/auto-response/';
     const delaySecs =


### PR DESCRIPTION
## Summary
- ensure AutoResponseSettings save handler always triggers request

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d82d1e690832d9288c08b9ef23ea1