### PR TITLE
Add responsive drawer and update home layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,12 +11,22 @@ import {
   AppBar,
   Toolbar,
   Typography,
-
   Button,
   CssBaseline,
   ThemeProvider,
   createTheme,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Box,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 
 // --- Material-UI Icons ---
 import HomeIcon from '@mui/icons-material/Home';
@@ -55,42 +65,132 @@ axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL
 
 
 // ---------------------------------------------
-// Main component with all routes
+// Main component with all routes and responsive drawer
 // ---------------------------------------------
-const App: React.FC = () => (
-  <ThemeProvider theme={theme}>
-    <CssBaseline />
-    <Router>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            Yelp Integration Dashboard
-          </Typography>
-          <Button color="inherit" component={RouterLink} to="/" startIcon={<HomeIcon />}>Home</Button>
-          <Button color="inherit" component={RouterLink} to="/events" startIcon={<EventIcon />}>Events</Button>
-          <Button color="inherit" component={RouterLink} to="/businesses" startIcon={<BusinessIcon />}>Businesses</Button>
-          <Button color="inherit" component={RouterLink} to="/tokens" startIcon={<VpnKeyIcon />}>Tokens</Button>
-          <Button color="inherit" component={RouterLink} to="/tasks" startIcon={<ListAltIcon />}>Tasks</Button>
-          <Button color="inherit" component={RouterLink} to="/templates" startIcon={<ListAltIcon />}>Templates</Button>
-        </Toolbar>
-      </AppBar>
-      <main>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/events" element={<EventsPage />} />
-          <Route path="/events/:id" element={<EventDetail />} />
-          <Route path="/leads/:id" element={<ClientDetails />} />
-          <Route path="/auth" element={<YelpAuth />} />
-          <Route path="/callback" element={<YelpCallback />} />
-          <Route path="/businesses" element={<BusinessSelector />} />
-          <Route path="/settings" element={<AutoResponseSettings />} />
-          <Route path="/tokens" element={<TokenStatus />} />
-          <Route path="/tasks" element={<TaskLogs />} />
-          <Route path="/templates" element={<SettingsTemplates />} />
-        </Routes>
-      </main>
-    </Router>
-  </ThemeProvider>
-);
+const drawerWidth = 240;
+
+const App: React.FC = () => {
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const themeHook = useTheme();
+  const isMobile = useMediaQuery(themeHook.breakpoints.down('sm'));
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(prev => !prev);
+  };
+
+  const drawer = (
+    <div>
+      <Toolbar />
+      <List>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <HomeIcon />
+            </ListItemIcon>
+            <ListItemText primary="Home" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/events" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <EventIcon />
+            </ListItemIcon>
+            <ListItemText primary="Events" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/businesses" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <BusinessIcon />
+            </ListItemIcon>
+            <ListItemText primary="Businesses" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/tokens" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <VpnKeyIcon />
+            </ListItemIcon>
+            <ListItemText primary="Tokens" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/tasks" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <ListAltIcon />
+            </ListItemIcon>
+            <ListItemText primary="Tasks" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/templates" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <ListAltIcon />
+            </ListItemIcon>
+            <ListItemText primary="Templates" />
+          </ListItemButton>
+        </ListItem>
+      </List>
+    </div>
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Router>
+        <Box sx={{ display: 'flex' }}>
+          <AppBar position="fixed" sx={{ zIndex: themeHook.zIndex.drawer + 1 }}>
+            <Toolbar>
+              {isMobile && (
+                <IconButton
+                  color="inherit"
+                  edge="start"
+                  onClick={handleDrawerToggle}
+                  sx={{ mr: 2, display: { sm: 'none' } }}
+                >
+                  <MenuIcon />
+                </IconButton>
+              )}
+              <Typography variant="h6" noWrap component="div">
+                Yelp Integration Dashboard
+              </Typography>
+            </Toolbar>
+          </AppBar>
+
+          <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }} aria-label="mailbox folders">
+            <Drawer
+              variant={isMobile ? 'temporary' : 'permanent'}
+              open={isMobile ? mobileOpen : true}
+              onClose={handleDrawerToggle}
+              ModalProps={{ keepMounted: true }}
+              sx={{
+                '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' },
+              }}
+            >
+              {drawer}
+            </Drawer>
+          </Box>
+
+          <Box component="main" sx={{ flexGrow: 1, p: 3, width: { sm: `calc(100% - ${drawerWidth}px)` } }}>
+            <Toolbar />
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/events" element={<EventsPage />} />
+              <Route path="/events/:id" element={<EventDetail />} />
+              <Route path="/leads/:id" element={<ClientDetails />} />
+              <Route path="/auth" element={<YelpAuth />} />
+              <Route path="/callback" element={<YelpCallback />} />
+              <Route path="/businesses" element={<BusinessSelector />} />
+              <Route path="/settings" element={<AutoResponseSettings />} />
+              <Route path="/tokens" element={<TokenStatus />} />
+              <Route path="/tasks" element={<TaskLogs />} />
+              <Route path="/templates" element={<SettingsTemplates />} />
+            </Routes>
+          </Box>
+        </Box>
+      </Router>
+    </ThemeProvider>
+  );
+};
 
 export default App;

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 // --- Material-UI Imports ---
@@ -11,10 +11,18 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  Paper,
   Snackbar,
   Alert,
-  Box,
+  Grid,
+  Card,
+  CardContent,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  Button,
+  useMediaQuery,
+  useTheme,
+  Grow,
 } from '@mui/material';
 
 // --- Material-UI Icons ---
@@ -26,6 +34,10 @@ import ListAltIcon from '@mui/icons-material/ListAlt';
 
 const Home: FC = () => {
   const [alertOpen, setAlertOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   useEffect(() => {
     axios.get('/tokens/')
@@ -51,71 +63,73 @@ const Home: FC = () => {
   };
 
   return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'linear-gradient(to right, #e1f5fe, #e3f2fd)',
-        py: 8,
-      }}
-    >
-      <Container maxWidth="md">
-        <Paper
-          elevation={6}
-          sx={{ p: 4, borderRadius: 3, backgroundColor: 'rgba(255,255,255,0.9)' }}
-        >
-          <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to the Yelp Integration Dashboard!
-          </Typography>
-        <Typography variant="body1" color="text.secondary" paragraph>
-          This dashboard helps you manage your Yelp events, leads, and automated responses.
-          Select an action from the list below to get started.
-        </Typography>
-        <List>
-          <ListItem disablePadding>
-            <ListItemButton component={RouterLink} to="/events">
-              <ListItemIcon>
-                <EventIcon />
-              </ListItemIcon>
-              <ListItemText primary="View Events" />
-            </ListItemButton>
-          </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton component={RouterLink} to="/settings">
-            <ListItemIcon>
-              <SettingsIcon />
-            </ListItemIcon>
-            <ListItemText primary="Auto-response Settings" />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton component={RouterLink} to="/tokens">
-            <ListItemIcon>
-              <AccessTimeIcon />
-            </ListItemIcon>
-            <ListItemText primary="Token Status" />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton component={RouterLink} to="/tasks">
-            <ListItemIcon>
-              <ListAltIcon />
-            </ListItemIcon>
-            <ListItemText primary="Celery Tasks" />
-          </ListItemButton>
-        </ListItem>
-          <ListItem disablePadding>
-            <ListItemButton component={RouterLink} to="/auth">
-              <ListItemIcon>
-                <VpnKeyIcon />
-              </ListItemIcon>
-              <ListItemText primary="Authorize with Yelp" />
-            </ListItemButton>
-          </ListItem>
-        </List>
-      </Paper>
+    <Container maxWidth="lg" sx={{ mt: isMobile ? 2 : 4 }}>
+      <Grid container spacing={2}>
+        <Grow in timeout={500}>
+          <Grid item xs={12} md={8}>
+            <Card sx={{ p: 3, mb: 2 }}>
+              <CardContent>
+                <Typography variant="h4" gutterBottom>
+                  Welcome to the Yelp Integration Dashboard!
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                  This dashboard helps you manage your Yelp events, leads and automated responses. Select an action from the list to get started.
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grow>
+        <Grow in timeout={700}>
+          <Grid item xs={12} md={4}>
+            <Card sx={{ p: 3, mb: 2 }}>
+              <CardContent>
+                <List>
+                  <ListItem disablePadding>
+                    <ListItemButton component={RouterLink} to="/events">
+                      <ListItemIcon>
+                        <EventIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="View Events" />
+                    </ListItemButton>
+                  </ListItem>
+                  <ListItem disablePadding>
+                    <ListItemButton component={RouterLink} to="/settings">
+                      <ListItemIcon>
+                        <SettingsIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="Auto-response Settings" />
+                    </ListItemButton>
+                  </ListItem>
+                  <ListItem disablePadding>
+                    <ListItemButton component={RouterLink} to="/tokens">
+                      <ListItemIcon>
+                        <AccessTimeIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="Token Status" />
+                    </ListItemButton>
+                  </ListItem>
+                  <ListItem disablePadding>
+                    <ListItemButton component={RouterLink} to="/tasks">
+                      <ListItemIcon>
+                        <ListAltIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="Celery Tasks" />
+                    </ListItemButton>
+                  </ListItem>
+                  <ListItem disablePadding>
+                    <ListItemButton onClick={() => setDialogOpen(true)}>
+                      <ListItemIcon>
+                        <VpnKeyIcon />
+                      </ListItemIcon>
+                      <ListItemText primary="Authorize with Yelp" />
+                    </ListItemButton>
+                  </ListItem>
+                </List>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grow>
+      </Grid>
       <Snackbar
         open={alertOpen}
         onClose={handleCloseAlert}
@@ -125,8 +139,16 @@ const Home: FC = () => {
           One or more refresh tokens expired. Please reauthorize.
         </Alert>
       </Snackbar>
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+        <DialogTitle>Authorize with Yelp?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button onClick={() => { setDialogOpen(false); navigate('/auth'); }} autoFocus>
+            Continue
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Container>
-    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace top nav with responsive Drawer navigation
- redesign Home page with Grid layout, Grow animations, Snackbar and Dialog

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc921135c832d9f2ad97850fc2f69