### PR TITLE
Fix MUI Grid props

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -66,7 +66,7 @@ const Home: FC = () => {
     <Container maxWidth="lg" sx={{ mt: isMobile ? 2 : 4 }}>
       <Grid container spacing={2}>
         <Grow in timeout={500}>
-          <Grid xs={12} md={8}>
+          <Grid item xs={12} md={8}>
             <Card sx={{ p: 3, mb: 2 }}>
               <CardContent>
                 <Typography variant="h4" gutterBottom>
@@ -80,7 +80,7 @@ const Home: FC = () => {
           </Grid>
         </Grow>
         <Grow in timeout={700}>
-          <Grid xs={12} md={4}>
+          <Grid item xs={12} md={4}>
             <Card sx={{ p: 3, mb: 2 }}>
               <CardContent>
                 <List>


### PR DESCRIPTION
## Summary
- fix Grid components to use `item` prop to allow `xs`/`md` sizing

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685e11c30a64832d942c38da1c84fd8a