### PR TITLE
Handle phone opt‑in events

### DIFF
--- a/backend/webhooks/migrations/0030_leaddetail_phone_opt_in.py
+++ b/backend/webhooks/migrations/0030_leaddetail_phone_opt_in.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webhooks', '0029_autoresponsesettingstemplate_followups'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='leaddetail',
+            name='phone_opt_in',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -219,6 +219,7 @@ class LeadDetail(models.Model):
     last_event_time                = models.DateTimeField(null=True, blank=True)
     user_display_name              = models.CharField(max_length=100, blank=True)
     project                        = models.JSONField()
+    phone_opt_in                   = models.BooleanField(default=False)
     created_at                     = models.DateTimeField(auto_now_add=True)
     updated_at                     = models.DateTimeField(auto_now=True)
 

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -197,6 +197,7 @@ class LeadDetailSerializer(serializers.ModelSerializer):
             'last_event_time',
             'user_display_name',
             'project',
+            'phone_opt_in',
             'created_at',
             'updated_at',
         ]

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -134,6 +134,8 @@ class WebhookView(APIView):
                 logger.info(f"[WEBHOOK] Upserting LeadEvent id={eid} for lead={lid}")
                 obj, created = safe_update_or_create(LeadEvent, defaults=defaults, event_id=eid)
                 logger.info(f"[WEBHOOK] LeadEvent saved pk={obj.pk}, created={created}")
+                if e.get("event_type") == "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT":
+                    LeadDetail.objects.filter(lead_id=lid).update(phone_opt_in=True)
 
         return Response({"status": "received"}, status=status.HTTP_201_CREATED)
 

--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   Divider,
   CircularProgress,
+  Chip,
 } from '@mui/material';
 
 interface Props {
@@ -135,6 +136,10 @@ const NewEvents: FC<Props> = ({
                       {detail.project.job_names.join(', ')}
                     </Typography>
                   )}
+
+                {detail?.phone_opt_in && (
+                  <Chip label="Phone Opt-In" color="success" size="small" />
+                )}
 
                 {upd.event_type && (
                   <Typography variant="body2">

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -156,6 +156,10 @@ const NewLeads: FC<Props> = ({
                   </Typography>
                 )}
 
+                {detail.phone_opt_in && (
+                  <Chip label="Phone Opt-In" color="success" size="small" />
+                )}
+
                 {/* Buttons */}
                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
                   <Button

--- a/frontend/src/EventsPage/types.ts
+++ b/frontend/src/EventsPage/types.ts
@@ -50,6 +50,7 @@ export interface LeadDetail {
     }>;
     [key: string]: any;
   };
+  phone_opt_in?: boolean;
   created_at?: string;
   updated_at?: string;
   // Add other fields here if needed


### PR DESCRIPTION
## Summary
- add `phone_opt_in` field to `LeadDetail`
- expose the new field via API
- mark leads as opted in when phone events arrive
- show phone opt‑in status for leads and events in the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e600944ec832d82d3af9a95765baa