### PR TITLE
Update AutoResponse settings UI

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -15,6 +15,8 @@ import {
   Box,
   Select,
   MenuItem,
+  Tabs,
+  Tab,
   Card,
   CardActionArea,
   CardContent,
@@ -694,15 +696,14 @@ const AutoResponseSettings: FC = () => {
           ))}
         </Select>
 
-        <Select
+        <Tabs
           value={phoneOptIn ? 'yes' : 'no'}
-          onChange={e => setPhoneOptIn(e.target.value === 'yes')}
-          size="small"
+          onChange={(_, v) => setPhoneOptIn(v === 'yes')}
           sx={{ mt: 2, ml: 2 }}
         >
-          <MenuItem value="no">Phone not provided</MenuItem>
-          <MenuItem value="yes">Phone available</MenuItem>
-        </Select>
+          <Tab label="Phone not provided" value="no" />
+          <Tab label="Phone available" value="yes" />
+        </Tabs>
       </Box>
 
       {selectedBusiness && (() => {


### PR DESCRIPTION
## Summary
- use tabs to switch between phone-not-provided and phone-available settings

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: Django not installed)*


------
https://chatgpt.com/codex/tasks/task_e_685e87e9fef8832db3ab3cb9f95db939