### PR TITLE
Support phone-based follow‑up templates

### DIFF
--- a/backend/webhooks/migrations/0032_followuptemplate_phone_opt_in.py
+++ b/backend/webhooks/migrations/0032_followuptemplate_phone_opt_in.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0031_autoresponsesettings_phone_opt_in'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='followuptemplate',
+            name='phone_opt_in',
+            field=models.BooleanField(default=False,
+                help_text='Use this template when consumer phone number is available'),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -140,6 +140,10 @@ class FollowUpTemplate(models.Model):
         on_delete=models.CASCADE,
         help_text="Який бізнес використовує цей шаблон. Null → шаблон за замовчуванням",
     )
+    phone_opt_in = models.BooleanField(
+        default=False,
+        help_text="Use this template when consumer phone number is available",
+    )
     name = models.CharField(
         max_length=100,
         help_text="Лаконічна назва шаблону"

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -84,6 +84,7 @@ class DurationSecondsField(serializers.IntegerField):
 class FollowUpTemplateSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(read_only=True)
     business_id = serializers.CharField(source='business.business_id', allow_null=True, required=False)
+    phone_opt_in = serializers.BooleanField(required=False)
     delay = DurationSecondsField(
         help_text="Затримка перед першим follow-up в секундах",
         write_only=False  # дозволяємо як читати, так і писати
@@ -94,6 +95,7 @@ class FollowUpTemplateSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'business_id',
+            'phone_opt_in',
             'name',
             'template',
             'delay',
@@ -106,6 +108,7 @@ class FollowUpTemplateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         secs = validated_data.pop('delay')
         biz_info = validated_data.pop('business', None)
+        phone_opt_in = validated_data.pop('phone_opt_in', False)
         if isinstance(biz_info, dict):
             bid = biz_info.get('business_id')
             validated_data['business'] = YelpBusiness.objects.filter(business_id=bid).first() if bid else None
@@ -114,6 +117,7 @@ class FollowUpTemplateSerializer(serializers.ModelSerializer):
         else:
             validated_data['business'] = None
         validated_data['delay'] = timedelta(seconds=secs)
+        validated_data['phone_opt_in'] = phone_opt_in
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
@@ -121,6 +125,7 @@ class FollowUpTemplateSerializer(serializers.ModelSerializer):
             secs = validated_data.pop('delay')
             validated_data['delay'] = timedelta(seconds=secs)
         biz_info = validated_data.pop('business', None)
+        phone_opt_in = validated_data.pop('phone_opt_in', None)
         if biz_info is not None:
             if isinstance(biz_info, dict):
                 bid = biz_info.get('business_id')
@@ -129,6 +134,8 @@ class FollowUpTemplateSerializer(serializers.ModelSerializer):
                 instance.business = biz_info
             else:
                 instance.business = None
+        if phone_opt_in is not None:
+            instance.phone_opt_in = phone_opt_in
         return super().update(instance, validated_data)
 
 

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -290,9 +290,17 @@ class WebhookView(APIView):
                 f"[AUTO-RESPONSE] Built-in follow-up scheduled at {due2.isoformat()}"
             )
 
-        tpls = FollowUpTemplate.objects.filter(active=True, business__business_id=biz_id)
+        tpls = FollowUpTemplate.objects.filter(
+            active=True,
+            phone_opt_in=phone_opt_in,
+            business__business_id=biz_id,
+        )
         if not tpls.exists():
-            tpls = FollowUpTemplate.objects.filter(active=True, business__isnull=True)
+            tpls = FollowUpTemplate.objects.filter(
+                active=True,
+                phone_opt_in=phone_opt_in,
+                business__isnull=True,
+            )
         business = YelpBusiness.objects.filter(business_id=biz_id).first()
         for tmpl in tpls:
             delay = int(tmpl.delay.total_seconds())

--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -281,7 +281,10 @@ const AutoResponseSettings: FC = () => {
 
   const loadTemplates = (biz?: string) => {
     setTplLoading(true);
-    const url = biz ? `/follow-up-templates/?business_id=${biz}` : '/follow-up-templates/';
+    const params = new URLSearchParams();
+    params.append('phone_opt_in', phoneOptIn ? 'true' : 'false');
+    if (biz) params.append('business_id', biz);
+    const url = `/follow-up-templates/?${params.toString()}`;
     axios.get<FollowUpTemplate[]>(url)
       .then(res => {
         setTemplates(res.data);
@@ -497,7 +500,10 @@ const AutoResponseSettings: FC = () => {
         follow_up_templates: initialSettings.current?.follow_up_templates || [],
       };
 
-      const bizParam = selectedBusiness ? `?business_id=${selectedBusiness}` : '';
+      const params = new URLSearchParams();
+      params.append('phone_opt_in', phoneOptIn ? 'true' : 'false');
+      if (selectedBusiness) params.append('business_id', selectedBusiness);
+      const bizParam = `?${params.toString()}`;
 
       // remove templates that were loaded initially but no longer present
       const toDelete = loadedTemplateIds.current.filter(
@@ -547,7 +553,10 @@ const AutoResponseSettings: FC = () => {
   // add new template
   const handleAddTemplate = () => {
     setTplLoading(true);
-    const url = selectedBusiness ? `/follow-up-templates/?business_id=${selectedBusiness}` : '/follow-up-templates/';
+    const params = new URLSearchParams();
+    params.append('phone_opt_in', phoneOptIn ? 'true' : 'false');
+    if (selectedBusiness) params.append('business_id', selectedBusiness);
+    const url = `/follow-up-templates/?${params.toString()}`;
     const delaySecs =
       newDelayDays * 86400 +
       newDelayHours * 3600 +
@@ -594,9 +603,10 @@ const AutoResponseSettings: FC = () => {
   const handleUpdateTemplate = () => {
     if (!editingTpl) return;
     setTplLoading(true);
-    const url = selectedBusiness
-      ? `/follow-up-templates/${editingTpl.id}/?business_id=${selectedBusiness}`
-      : `/follow-up-templates/${editingTpl.id}/`;
+    const params = new URLSearchParams();
+    params.append('phone_opt_in', phoneOptIn ? 'true' : 'false');
+    if (selectedBusiness) params.append('business_id', selectedBusiness);
+    const url = `/follow-up-templates/${editingTpl.id}/?${params.toString()}`;
     const delaySecs =
       editDelayDays * 86400 +
       editDelayHours * 3600 +
@@ -622,7 +632,10 @@ const AutoResponseSettings: FC = () => {
 
   // delete a template
   const handleDeleteTemplate = (tplId: number) => {
-    const url = selectedBusiness ? `/follow-up-templates/${tplId}/?business_id=${selectedBusiness}` : `/follow-up-templates/${tplId}/`;
+    const params = new URLSearchParams();
+    params.append('phone_opt_in', phoneOptIn ? 'true' : 'false');
+    if (selectedBusiness) params.append('business_id', selectedBusiness);
+    const url = `/follow-up-templates/${tplId}/?${params.toString()}`;
     axios.delete(url)
       .then(() => {
         setTemplates(prev => prev.filter(t => t.id !== tplId));


### PR DESCRIPTION
## Summary
- add `phone_opt_in` flag to `FollowUpTemplate` model
- expose phone flag in serializer
- filter follow-up templates by phone flag in API and scheduling logic
- pass phone flag in frontend requests
- migration for the new field

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8be0ce70832d99182e3ee9e40759