### PR TITLE
Add LeadPendingTask tracking

### DIFF
--- a/backend/webhooks/migrations/0033_leadpendingtask.py
+++ b/backend/webhooks/migrations/0033_leadpendingtask.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webhooks', '0032_followuptemplate_phone_opt_in'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LeadPendingTask',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('lead_id', models.CharField(max_length=64, db_index=True)),
+                ('task_id', models.CharField(max_length=128, unique=True)),
+                ('phone_opt_in', models.BooleanField()),
+                ('active', models.BooleanField(default=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -282,6 +282,19 @@ class CeleryTaskLog(models.Model):
         return f"{self.task_id} {self.name} {self.status}"
 
 
+class LeadPendingTask(models.Model):
+    """Track Celery tasks scheduled for a lead."""
+
+    lead_id = models.CharField(max_length=64, db_index=True)
+    task_id = models.CharField(max_length=128, unique=True)
+    phone_opt_in = models.BooleanField()
+    active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.task_id} for {self.lead_id}"
+
+
 class AutoResponseSettingsTemplate(models.Model):
     """Stored presets for AutoResponseSettings."""
 


### PR DESCRIPTION
## Summary
- add `LeadPendingTask` model and migration
- save Celery task ids when scheduling auto responses
- revoke pending tasks without phone when a phone number arrives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e959050ec832d88d898381c815102