### PR TITLE
Fix template dropdown state

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -417,6 +417,12 @@ const AutoResponseSettings: FC = () => {
     loadTemplates(selectedBusiness || undefined);
   }, [selectedBusiness, phoneOptIn]);
 
+  // reset template selection when switching phone opt-in tab
+  useEffect(() => {
+    setSelectedTemplateId('current');
+    setAppliedTemplateId(null);
+  }, [phoneOptIn]);
+
   // reload templates when other tabs modify them
   useEffect(() => {
     const handler = (e: StorageEvent) => {


### PR DESCRIPTION
## Summary
- ensure Phone Available tab resets its settings template dropdown

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `pip3 install -r backend/requirements.txt` *(fails: could not find Django due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685eb1cb8ed8832db2c69732cdcb7148