### PR TITLE
Fix template dropdown per tab

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -154,7 +154,10 @@ const AutoResponseSettings: FC = () => {
 
   // saved settings templates
   const [settingsTemplates, setSettingsTemplates] = useState<SettingsTemplate[]>([]);
-  const [selectedTemplateId, setSelectedTemplateId] = useState<number | 'current' | ''>('');
+  const [selectedTemplateIdNoPhone, setSelectedTemplateIdNoPhone] =
+    useState<number | 'current' | ''>('current');
+  const [selectedTemplateIdWithPhone, setSelectedTemplateIdWithPhone] =
+    useState<number | 'current' | ''>('current');
 
   // track initial settings and applied template
   const initialSettings = useRef<AutoResponseSettingsData | null>(null);
@@ -654,10 +657,14 @@ const AutoResponseSettings: FC = () => {
       <Box sx={{ mb: 2 }}>
         <Box>
           <Select
-            value={selectedTemplateId}
+            value={phoneOptIn ? selectedTemplateIdWithPhone : selectedTemplateIdNoPhone}
             onChange={e => {
               const val = e.target.value as any;
-              setSelectedTemplateId(val);
+              if (phoneOptIn) {
+                setSelectedTemplateIdWithPhone(val);
+              } else {
+                setSelectedTemplateIdNoPhone(val);
+              }
 
               if (initialSettings.current) {
                 if (val === 'current' || val === '') {


### PR DESCRIPTION
## Summary
- keep separate selected template ids for each phone response tab
- update template dropdown to use state tied to the current tab

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb3aea444832dadaf6d123fb7fbc5