### PR TITLE
Default current template

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -689,13 +689,9 @@ const AutoResponseSettings: FC = () => {
                 }
               }
             }}
-            displayEmpty
             size="small"
             sx={{ minWidth: 200 }}
           >
-            <MenuItem value="">
-              <em>Select Template</em>
-            </MenuItem>
             <MenuItem value="current">Current</MenuItem>
             {settingsTemplates.map(t => (
               <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>


### PR DESCRIPTION
## Summary
- remove `Select Template` option in settings template dropdown
- keep `Current` as the default selected value

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc790068832d8071cffe20e01630