### PR TITLE
Add PostgreSQL support and data migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Yelp1 Backend Migration
+
+This project was originally configured with SQLite. To run it with PostgreSQL,
+Docker Compose now includes a `db` service using Postgres 16. Default
+credentials are:
+
+- **User**: `yelproot`
+- **Password**: `yelproot`
+- **Database**: `postgres`
+
+The Django services read these credentials via environment variables and use
+PostgreSQL when `DB_ENGINE=postgres`.
+
+## Migrating existing data
+
+A helper script is provided to migrate data from the previous SQLite database
+to PostgreSQL:
+
+```bash
+python backend/scripts/migrate_sqlite_to_postgres.py
+```
+
+The script dumps all data using the SQLite configuration and then loads it into
+the Postgres database after applying migrations. Ensure the Postgres service is
+running before executing the script.
+

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -130,12 +130,26 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "dbdata" / "db.sqlite3",
+DB_ENGINE = os.getenv("DB_ENGINE", "sqlite")
+
+if DB_ENGINE == "postgres":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.getenv("POSTGRES_DB", "postgres"),
+            "USER": os.getenv("POSTGRES_USER", "yelproot"),
+            "PASSWORD": os.getenv("POSTGRES_PASSWORD", "yelproot"),
+            "HOST": os.getenv("POSTGRES_HOST", "localhost"),
+            "PORT": os.getenv("POSTGRES_PORT", "5432"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "dbdata" / "db.sqlite3",
+        }
+    }
 
 
 # Password validation

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -16,17 +16,33 @@ services:
       ALLOWED_HOSTS: "127.0.0.1,localhost"
       CELERY_BROKER_URL: "redis://redis:6379/0"
       CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+      DB_ENGINE: "postgres"
+      POSTGRES_HOST: "db"
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: "yelproot"
+      POSTGRES_PASSWORD: "yelproot"
+      POSTGRES_DB: "postgres"
     volumes:
       - .:/app
-      - ./dbdata:/app/dbdata
     ports:
       - "8000:8000"
     depends_on:
       - redis
+      - db
 
   redis:
     image: redis:7
     restart: unless-stopped
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: "yelproot"
+      POSTGRES_PASSWORD: "yelproot"
+      POSTGRES_DB: "postgres"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   celery:
     build:
@@ -37,11 +53,17 @@ services:
     environment:
       CELERY_BROKER_URL: "redis://redis:6379/0"
       CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+      DB_ENGINE: "postgres"
+      POSTGRES_HOST: "db"
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: "yelproot"
+      POSTGRES_PASSWORD: "yelproot"
+      POSTGRES_DB: "postgres"
     volumes:
       - .:/app
     depends_on:
       - redis
-      - web
+      - db
 
   celery-beat:
     build:
@@ -52,8 +74,18 @@ services:
     environment:
       CELERY_BROKER_URL: "redis://redis:6379/0"
       CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+      DB_ENGINE: "postgres"
+      POSTGRES_HOST: "db"
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: "yelproot"
+      POSTGRES_PASSWORD: "yelproot"
+      POSTGRES_DB: "postgres"
     volumes:
       - .:/app
     depends_on:
       - redis
-      - web
+      - db
+
+volumes:
+  postgres_data:
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ gspread
 google-auth
 cryptography
 django-filter
+psycopg2-binary
 

--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+import tempfile
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+MANAGE = BASE_DIR / "manage.py"
+
+def dump_sqlite(dump_path):
+    env = os.environ.copy()
+    env["DB_ENGINE"] = "sqlite"
+    subprocess.check_call(["python", str(MANAGE), "dumpdata", "--indent", "2", "-o", str(dump_path)], env=env)
+
+def load_postgres(dump_path):
+    env = os.environ.copy()
+    env.update({
+        "DB_ENGINE": "postgres",
+        "POSTGRES_USER": env.get("POSTGRES_USER", "yelproot"),
+        "POSTGRES_PASSWORD": env.get("POSTGRES_PASSWORD", "yelproot"),
+        "POSTGRES_DB": env.get("POSTGRES_DB", "postgres"),
+        "POSTGRES_HOST": env.get("POSTGRES_HOST", "localhost"),
+        "POSTGRES_PORT": env.get("POSTGRES_PORT", "5432"),
+    })
+    subprocess.check_call(["python", str(MANAGE), "migrate"], env=env)
+    subprocess.check_call(["python", str(MANAGE), "loaddata", str(dump_path)], env=env)
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        dump_file = Path(tmp) / "data.json"
+        dump_sqlite(dump_file)
+        load_postgres(dump_file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add PostgreSQL database settings with env vars
- update docker-compose to run Postgres service and use it
- install `psycopg2-binary`
- provide script to migrate data from SQLite to Postgres
- document the new setup and migration procedure

## Testing
- `python -m py_compile backend/config/settings.py`
- `python -m py_compile backend/scripts/migrate_sqlite_to_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_685ed745b2e0832db315fad7d7841951