### PR TITLE
Expose Postgres for host connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,18 @@ The script dumps all data using the SQLite configuration and then loads it into
 the Postgres database after applying migrations. Ensure the Postgres service is
 running before executing the script.
 
+## Connecting from outside Docker
+
+If you want to use a local psql client or GUI to access the database, expose
+the Postgres port in `backend/docker-compose.yml`:
+
+```yaml
+  db:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+```
+
+Restart the stack with `docker compose up -d`. The database is then available
+at `localhost:5432` with the credentials listed above.
+

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -37,6 +37,8 @@ services:
   db:
     image: postgres:16
     restart: unless-stopped
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_USER: "yelproot"
       POSTGRES_PASSWORD: "yelproot"


### PR DESCRIPTION
## Summary
- expose Postgres port in `backend/docker-compose.yml`
- document how to access the database from the host

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685edd669e00832dabec895ff68ee5eb