### PR TITLE
Add md5 auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ credentials are:
 - **Password**: `yelproot`
 - **Database**: `postgres`
 
+The `db` service sets `POSTGRES_HOST_AUTH_METHOD=md5` so host connections always
+require a password.
+
 The Django services read these credentials via environment variables and use
 PostgreSQL when `DB_ENGINE=postgres`.
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       POSTGRES_USER: "yelproot"
       POSTGRES_PASSWORD: "yelproot"
       POSTGRES_DB: "postgres"
+      POSTGRES_HOST_AUTH_METHOD: "md5"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## Summary
- require md5 authentication for Postgres host connections
- document `POSTGRES_HOST_AUTH_METHOD` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee3682e84832d9641b8f08ffd7812