### PR TITLE
Map Postgres to host port 5433

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ the Postgres port in `backend/docker-compose.yml`:
   db:
     image: postgres:16
     ports:
-      - "5432:5432"
+      - "5433:5432"
 ```
 
 Restart the stack with `docker compose up -d`. The database is then available
-at `localhost:5432` with the credentials listed above.
+at `localhost:5433` with the credentials listed above.
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     image: postgres:16
     restart: unless-stopped
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_USER: "yelproot"
       POSTGRES_PASSWORD: "yelproot"


### PR DESCRIPTION
## Summary
- expose Postgres on host port 5433 to avoid clashes
- update README to document the new port mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef00247d4832d8f6dd9e0ce49a5ee