### PR TITLE
Fix sequence after default AutoResponseSettings insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ The script dumps all data using the SQLite configuration and then loads it into
 the Postgres database after applying migrations. Ensure the Postgres service is
 running before executing the script.
 
+After seeding the `AutoResponseSettings` table with the initial row (`id=1`),
+update the PostgreSQL sequence so new records receive the next available ID:
+
+```sql
+SELECT setval(pg_get_serial_sequence('webhooks_autoresponsesettings','id'),
+              (SELECT MAX(id) FROM webhooks_autoresponsesettings));
+```
+
+Migration `0035_update_autoresponsesettings_sequence` runs this query
+automatically when migrations are applied.
+
 ## Connecting from outside Docker
 
 If you want to use a local psql client or GUI to access the database, expose

--- a/backend/webhooks/migrations/0035_update_autoresponsesettings_sequence.py
+++ b/backend/webhooks/migrations/0035_update_autoresponsesettings_sequence.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+SQL = """
+SELECT setval(
+    pg_get_serial_sequence('webhooks_autoresponsesettings','id'),
+    (SELECT MAX(id) FROM webhooks_autoresponsesettings)
+);
+"""
+
+def update_sequence(apps, schema_editor):
+    if schema_editor.connection.vendor != 'postgresql':
+        return
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(SQL)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webhooks', '0034_celerytasklog_traceback'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_sequence, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add migration that resets the `webhooks_autoresponsesettings` sequence
- document sequence fix in README

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685ef5a73970832da50b541a22bbb226