### PR TITLE
Fix NewEvents fallback to avoid endless Loading

### DIFF
--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -60,6 +60,12 @@ const NewEvents: FC<Props> = ({
           }
         } catch (err) {
           console.error('[new events] failed for', eventId, err);
+          const fallbackText =
+            upd?.event_content?.text || upd?.event_content?.fallback_text || '';
+          setEventInfo(prev => ({
+            ...prev,
+            [e.id]: { id: String(eventId), text: fallbackText },
+          }));
         }
       }
     })();


### PR DESCRIPTION
## Summary
- handle failure when loading event details

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624de20b68832d9935a75f2f1fffc9