### PR TITLE
Show all lead events

### DIFF
--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -253,7 +253,6 @@ const EventsPage: FC = () => {
     : events;
 
   const newEvents = filteredEvents
-    .filter(e => e.event_type === 'NEW_EVENT')
     .sort((a, b) => b.id - a.id);
   const unreadEventsCount = Math.max(0, totalEventsCount - viewedEvents.size);
 


### PR DESCRIPTION
## Summary
- show every LeadEvent on the events page

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686256ec94a4832dafe0cee16886f127