### PR TITLE
Remove Raw field from event cards

### DIFF
--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -147,9 +147,6 @@ const NewEvents: FC<Props> = ({
                   {new Date(e.updated_at).toLocaleString()}
                 </Typography>
 
-                <Typography variant="body2">
-                  <strong>Raw:</strong> {JSON.stringify(e.raw)}
-                </Typography>
 
                 <Divider />
 


### PR DESCRIPTION
## Summary
- clean up event view by removing the `Raw` field from the New Events page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862590f7a7c832d8441d1228eaeb353