### PR TITLE
Handle phone numbers in new events

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -101,6 +101,18 @@ class WebhookView(APIView):
                     ).update(phone_opt_in=True)
                     if updated:
                         self.handle_phone_available(lid)
+                if (
+                    upd.get("event_type") == "NEW_EVENT"
+                    and upd.get("user_type") == "CONSUMER"
+                ):
+                    content = upd.get("event_content", {}) or {}
+                    text = content.get("text") or content.get("fallback_text", "")
+                    if text and PHONE_RE.search(text):
+                        updated = LeadDetail.objects.filter(
+                            lead_id=lid, phone_in_text=False
+                        ).update(phone_in_text=True)
+                        if updated:
+                            self.handle_phone_available(lid)
         logger.info(f"[WEBHOOK] Lead IDs to process: {lead_ids}")
 
         for upd in updates:

--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -95,6 +95,9 @@ const NewEvents: FC<Props> = ({
                 {detail?.phone_opt_in && (
                   <Chip label="Phone Opt-In" color="success" size="small" />
                 )}
+                {detail?.phone_in_text && (
+                  <Chip label="Phone in text" color="info" size="small" />
+                )}
 
                 {e.event_type && (
                   <Typography variant="body2">

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -154,6 +154,9 @@ const NewLeads: FC<Props> = ({
                 {detail.phone_opt_in && (
                   <Chip label="Phone Opt-In" color="success" size="small" />
                 )}
+                {detail.phone_in_text && (
+                  <Chip label="Phone in text" color="info" size="small" />
+                )}
 
                 {/* Buttons */}
                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>

--- a/frontend/src/EventsPage/types.ts
+++ b/frontend/src/EventsPage/types.ts
@@ -51,6 +51,7 @@ export interface LeadDetail {
     [key: string]: any;
   };
   phone_opt_in?: boolean;
+  phone_in_text?: boolean;
   created_at?: string;
   updated_at?: string;
   // Add other fields here if needed


### PR DESCRIPTION
## Summary
- detect phone numbers inside incoming webhook updates
- surface `phone_in_text` flag in React UI
- display "Phone in text" chip for new leads and events

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686261849bb4832da679779560674296