### PR TITLE
Expose phone_in_dialog flag

### DIFF
--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -208,6 +208,7 @@ class LeadDetailSerializer(serializers.ModelSerializer):
             'project',
             'phone_opt_in',
             'phone_in_text',
+            'phone_in_dialog',
             'created_at',
             'updated_at',
         ]

--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -98,6 +98,9 @@ const NewEvents: FC<Props> = ({
                 {detail?.phone_in_text && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
+                {detail?.phone_in_dialog && (
+                  <Chip label="Phone in dialog" color="info" size="small" />
+                )}
 
                 {e.event_type && (
                   <Typography variant="body2">

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -157,6 +157,9 @@ const NewLeads: FC<Props> = ({
                 {detail.phone_in_text && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
+                {detail.phone_in_dialog && (
+                  <Chip label="Phone in dialog" color="info" size="small" />
+                )}
 
                 {/* Buttons */}
                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>

--- a/frontend/src/EventsPage/types.ts
+++ b/frontend/src/EventsPage/types.ts
@@ -52,6 +52,7 @@ export interface LeadDetail {
   };
   phone_opt_in?: boolean;
   phone_in_text?: boolean;
+  phone_in_dialog?: boolean;
   created_at?: string;
   updated_at?: string;
   // Add other fields here if needed


### PR DESCRIPTION
## Summary
- include `phone_in_dialog` in LeadDetailSerializer
- add `phone_in_dialog` to lead type definitions
- show a "Phone in dialog" chip on event/lead cards

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626d975884832d803efd83611e3826