### PR TITLE
Handle phone numbers in old webhook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ at `localhost:5433` with the credentials listed above.
 ## Webhook event processing
 
 When events are fetched from Yelp after a lead is created, the backend ignores
-consumer messages that occurred **before** the lead was processed. This prevents
-the initial lead message from cancelling pending auto-response tasks. Only events
-created after `ProcessedLead.processed_at` trigger phone number logic.
+consumer messages that occurred **before** the lead was processed **unless** the
+message contains a phone number. This prevents the initial lead message from
+cancelling pending auto-response tasks, while still capturing phone numbers that
+might appear in that first message. Events created after
+`ProcessedLead.processed_at` always trigger phone number logic.
 


### PR DESCRIPTION
## Summary
- process initial webhook events that include phone numbers
- ensure only new no-phone messages cancel scheduled tasks
- document updated webhook behavior
- test handling of phone numbers in initial events

## Testing
- `python manage.py test webhooks.tests.test_webhook_events.WebhookEventProcessingTests -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862d06cd7b4832d9d8cda387d757445