### PR TITLE
Update tab label

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -775,7 +775,7 @@ const AutoResponseSettings: FC = () => {
           sx={{ mt: 2, ml: 2 }}
         >
           <Tab label="Phone not provided" value="no" />
-          <Tab label="No Phone Number available" value="opt" />
+          <Tab label="No phone number available (Phone Opt-In)" value="opt" />
           <Tab label="Phone available" value="text" />
         </Tabs>
       </Box>


### PR DESCRIPTION
## Summary
- update tab label for no phone scenario in settings page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f1bea0f8832d8399b01b09850cdf