### PR TITLE
Fix duplicate follow-up scheduling

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -92,7 +92,7 @@ def log_task_schedule(sender=None, headers=None, **kwargs):
             get_task_log_model().objects.update_or_create(
                 task_id=task_id,
                 defaults={
-                    "name": sender,
+                    "name": _short_name(sender),
                     "args": args,
                     "kwargs": kargs,
                     "eta": schedule_time,
@@ -115,7 +115,7 @@ def log_task_start(sender=None, task_id=None, args=None, kwargs=None, **other):
     if updated == 0:
         model.objects.create(
             task_id=task_id,
-            name=getattr(sender, "name", str(sender)),
+            name=_short_name(getattr(sender, "name", str(sender))),
             args=args,
             kwargs=kwargs,
             started_at=timezone.now(),
@@ -150,7 +150,7 @@ def log_task_done(
             pass
         model.objects.create(
             task_id=task_id,
-            name=getattr(sender, "name", str(sender)),
+            name=_short_name(getattr(sender, "name", str(sender))),
             args=args,
             kwargs=kwargs,
             started_at=timezone.now(),

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -73,7 +73,7 @@ def _already_sent(lead_id: str, text: str) -> bool:
     # Consider tasks that are already scheduled or in progress to
     # avoid queuing duplicates while the first one hasn't finished yet
     return CeleryTaskLog.objects.filter(
-        name="send_follow_up",
+        name__endswith="send_follow_up",
         args__0=lead_id,
         args__1=text,
         status__in=["SCHEDULED", "STARTED", "SUCCESS"],


### PR DESCRIPTION
## Summary
- store the short task name in CeleryTaskLog
- detect already scheduled follow-ups using name suffix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863b19f45b0832d8d0ba3e9ec8e6152