### PR TITLE
Add Yelp subscriptions management

### DIFF
--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -9,7 +9,7 @@ from .views import (
     FollowUpTemplateListCreateView, FollowUpTemplateDetailView,
     AutoResponseSettingsTemplateListCreateView, AutoResponseSettingsTemplateDetailView,
     BusinessListView, BusinessLeadsView, BusinessEventsView,
-    YelpTokenListView,
+    SubscriptionProxyView, YelpTokenListView,
 )
 from .task_views import TaskLogListView, MessageTaskListView
 
@@ -74,6 +74,7 @@ urlpatterns = [
     path('businesses/', BusinessListView.as_view(), name='business-list'),
     path('leads/', BusinessLeadsView.as_view(), name='business-leads'),
     path('events/', BusinessEventsView.as_view(), name='business-events'),
+    path('businesses/subscriptions/', SubscriptionProxyView.as_view(), name='business-subscriptions'),
     path('yelp/leads/<str:lead_id>/', LeadDetailProxyView.as_view()),
     path(
         'yelp/leads/<str:lead_id>/attachments/<str:attachment_id>/',

--- a/backend/webhooks/views.py
+++ b/backend/webhooks/views.py
@@ -11,6 +11,7 @@ from .proxy_views import (
     BusinessListView,
     BusinessLeadsView,
     BusinessEventsView,
+    SubscriptionProxyView,
 )
 from .webhook_views import WebhookView, safe_update_or_create
 from .oauth_views import (
@@ -69,4 +70,5 @@ __all__ = [
     "YelpTokenListView",
     "AttachmentProxyView",
     "TaskLogListView",
+    "SubscriptionProxyView",
 ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import EventIcon from '@mui/icons-material/Event';
 import BusinessIcon from '@mui/icons-material/Business';
 import VpnKeyIcon from '@mui/icons-material/VpnKey';
 import ListAltIcon from '@mui/icons-material/ListAlt';
+import SubscriptionsIcon from '@mui/icons-material/Subscriptions';
 import EventDetail from "./Events/EventDetail";
 import EventsPage from "./EventsPage/EventsPage";
 import Home from "./Home";
@@ -46,6 +47,7 @@ import BusinessSelector from "./BusinessSelector";
 import TokenStatus from "./TokenStatus";
 import TaskLogs from "./TaskLogs";
 import SettingsTemplates from "./SettingsTemplates";
+import Subscriptions from "./Subscriptions";
 
 // A default theme for the application
 const theme = createTheme({
@@ -113,6 +115,14 @@ const App: FC = () => {
               <VpnKeyIcon />
             </ListItemIcon>
             <ListItemText primary="Tokens" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/subscriptions" onClick={() => setMobileOpen(false)}>
+            <ListItemIcon>
+              <SubscriptionsIcon />
+            </ListItemIcon>
+            <ListItemText primary="Subscriptions" />
           </ListItemButton>
         </ListItem>
         <ListItem disablePadding>
@@ -184,6 +194,7 @@ const App: FC = () => {
               <Route path="/businesses" element={<BusinessSelector />} />
               <Route path="/settings" element={<AutoResponseSettings />} />
               <Route path="/tokens" element={<TokenStatus />} />
+              <Route path="/subscriptions" element={<Subscriptions />} />
               <Route path="/tasks" element={<TaskLogs />} />
               <Route path="/templates" element={<SettingsTemplates />} />
             </Routes>

--- a/frontend/src/Subscriptions.tsx
+++ b/frontend/src/Subscriptions.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import {
+  Container,
+  Typography,
+  Box,
+  TextField,
+  Button,
+  Paper,
+  CircularProgress,
+} from '@mui/material';
+
+interface Subscription {
+  business_id: string;
+  subscribed_at: string;
+}
+
+const Subscriptions: React.FC = () => {
+  const [subs, setSubs] = useState<Subscription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newBiz, setNewBiz] = useState('');
+
+  const loadSubs = () => {
+    setLoading(true);
+    axios
+      .get<{ subscriptions: Subscription[] }>('/businesses/subscriptions/?subscription_type=WEBHOOK')
+      .then(res => setSubs(res.data.subscriptions || []))
+      .catch(() => setSubs([]))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadSubs();
+  }, []);
+
+  const handleSubscribe = () => {
+    if (!newBiz) return;
+    axios
+      .post('/businesses/subscriptions/', {
+        subscription_types: ['WEBHOOK'],
+        business_ids: [newBiz],
+      })
+      .then(loadSubs)
+      .catch(() => {});
+  };
+
+  const handleUnsubscribe = (bid: string) => {
+    axios
+      .delete('/businesses/subscriptions/', {
+        data: { subscription_types: ['WEBHOOK'], business_ids: [bid] },
+      })
+      .then(loadSubs)
+      .catch(() => {});
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Subscriptions
+      </Typography>
+      <Box sx={{ display: 'flex', mb: 2 }}>
+        <TextField
+          size="small"
+          label="Business ID"
+          value={newBiz}
+          onChange={e => setNewBiz(e.target.value)}
+          sx={{ mr: 1 }}
+        />
+        <Button variant="contained" onClick={handleSubscribe}>
+          Subscribe
+        </Button>
+      </Box>
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          {subs.map(s => (
+            <Paper key={s.business_id} sx={{ p: 2, mb: 1, display: 'flex', justifyContent: 'space-between' }}>
+              <Box>
+                <Typography variant="subtitle1">{s.business_id}</Typography>
+                <Typography variant="body2">
+                  {new Date(s.subscribed_at).toLocaleString()}
+                </Typography>
+              </Box>
+              <Button color="error" onClick={() => handleUnsubscribe(s.business_id)}>
+                Unsubscribe
+              </Button>
+            </Paper>
+          ))}
+          {subs.length === 0 && <Typography>No subscriptions</Typography>}
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default Subscriptions;


### PR DESCRIPTION
## Summary
- add SubscriptionProxyView to proxy Yelp business subscriptions
- expose new subscriptions endpoint in API
- export view from `views.py`
- create frontend `Subscriptions` page
- add subscriptions link in sidebar and routing

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c7a5f2d8832d9e0bdda896fbfa99