### PR TITLE
Rename Celery tasks label on frontend

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -113,7 +113,7 @@ const Home: FC = () => {
                       <ListItemIcon>
                         <ListAltIcon />
                       </ListItemIcon>
-                      <ListItemText primary="Celery Tasks" />
+                      <ListItemText primary="Planned Tasks" />
                     </ListItemButton>
                   </ListItem>
                   <ListItem disablePadding>

--- a/frontend/src/TaskLogs.tsx
+++ b/frontend/src/TaskLogs.tsx
@@ -99,7 +99,7 @@ const TaskLogs: React.FC = () => {
   return (
     <Container sx={{ mt: 4 }}>
       <Typography variant="h4" gutterBottom>
-        Celery Tasks
+        Planned Tasks
       </Typography>
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Completed" value="completed" />


### PR DESCRIPTION
## Summary
- rename the heading on the Tasks page
- update the navigation text

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: react-scripts not found)*
- `python backend/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863cc78fa88832da653acc486b6e5e1