### PR TITLE
Fix phone label text on settings

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -775,8 +775,8 @@ const AutoResponseSettings: FC = () => {
           sx={{ mt: 2, ml: 2 }}
         >
           <Tab label="Phone not provided" value="no" />
-          <Tab label="No phone number available (Phone Opt-In)" value="opt" />
-          <Tab label="Phone available" value="text" />
+          <Tab label="phone available (Phone Opt-In)" value="opt" />
+          <Tab label="real phone provided" value="text" />
         </Tabs>
       </Box>
 


### PR DESCRIPTION
## Summary
- rename tab labels on settings page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863ce34ecd8832db1b7c458cc5bb9e6