### PR TITLE
Detect phone number in additional info

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ cancelling pending auto-response tasks, while still capturing phone numbers that
 might appear in that first message. Events created after
 `ProcessedLead.processed_at` always trigger phone number logic.
 
+Phone numbers found in a lead's `additional_info` field also trigger the "real
+phone provided" flow when the lead is first processed.
+


### PR DESCRIPTION
## Summary
- auto-detect phone numbers in lead `additional_info`
- mention new behavior in README
- add regression test

## Testing
- `pytest -q webhooks/tests/test_webhook_events.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863d5af9714832dbc827919f18f0be9