### PR TITLE
Verify new leads using Yelp API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ might appear in that first message. Events created after
 Phone numbers found in a lead's `additional_info` field also trigger the "real
 phone provided" flow when the lead is first processed.
 
+Before marking an incoming update as a new lead, the backend queries
+`/businesses/{business_id}/lead_ids` to check whether the ID has already been
+seen. Only when the ID is missing from this list is the event treated as
+`"NEW_LEAD"`.
+


### PR DESCRIPTION
## Summary
- call `/businesses/{biz_id}/lead_ids` to verify lead is new
- warn if lead ID check fails
- test marking an update as NEW_LEAD only when appropriate
- document new Yelp API call in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863dbde0e74832d86edfa00542cffe3