### PR TITLE
Allow deployed frontend origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ Before marking an incoming update as a new lead, the backend queries
 seen. Only when the ID is missing from this list is the event treated as
 `"NEW_LEAD"`.
 
+## Frontend API configuration
+
+When building the React frontend for production, point it at your deployed
+backend by setting the `REACT_APP_API_BASE_URL` environment variable:
+
+```bash
+REACT_APP_API_BASE_URL=http://46.62.139.177:8000 npm run build
+```
+
+If this variable is omitted, the app falls back to `http://localhost:8000/api`.
+

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -26,7 +26,12 @@ SECRET_KEY = 'django-insecure-_8)i-uy_l-lq%@swb75enu8e4s)wumz1ap*f-hth9gxm)k3%lg
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['77e2-194-44-109-244.ngrok-free.app', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = [
+    '77e2-194-44-109-244.ngrok-free.app',
+    '127.0.0.1',
+    'localhost',
+    '46.62.139.177',
+]
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/1")
 CACHES = {
@@ -222,6 +227,7 @@ GOOGLE_SERVICE_ACCOUNT_FILE = BASE_DIR / "service_account.json"
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:3000',
     'http://localhost:3001',
+    'http://46.62.139.177:3000',
 ]
 
 CELERY_BEAT_SCHEDULE = {


### PR DESCRIPTION
## Summary
- add 46.62.139.177 to `ALLOWED_HOSTS`
- allow `http://46.62.139.177:3000` for CORS
- document how to set the frontend API base URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863e9a4fd38832db369f9c7fb5adaba