### PR TITLE
Update server configuration URLs

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -201,7 +201,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Yelp OAuth Settings
 YELP_CLIENT_ID = 'aqlct9xjUJHu0Lu5I0zW0Q'
 YELP_CLIENT_SECRET = 'obKNrCDl4i7Pgt8tjNmWA7Nq162QqPc2RvNqjS3BaGRBSRdkhO4rrR32o50UxYKq'
-YELP_OAUTH_REDIRECT_URI = 'http://localhost:8000/yelp/auth/callback/'
+YELP_OAUTH_REDIRECT_URI = 'http://46.62.139.177:8000/yelp/auth/callback/'
 YELP_AUTHORIZATION_URL = 'https://biz.yelp.com/oauth2/authorize'
 YELP_TOKEN_URL = 'https://api.yelp.com/oauth2/token'
 YELP_PARTNER_API_URL = 'https://partner-api.yelp.com/v3/businesses'
@@ -216,7 +216,7 @@ YELP_TOKEN_SECRET = os.getenv("YELP_TOKEN_SECRET", "0123456789ABCDEF0123456789AB
 GOOGLE_TIMEZONE_API_KEY = os.getenv("GOOGLE_TIMEZONE_API_KEY", "AIzaSyC3TB24rn-fp7IJ2m_T3PyMKLXuDSNOL9k")
 
 # Frontend URL
-FRONTEND_URL = 'http://localhost:3000'
+FRONTEND_URL = 'http://46.62.139.177:3000'
 
 # Google sheets
 GS_SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       DEBUG: "1"
       SECRET_KEY: "super-secret-key"
-      ALLOWED_HOSTS: "127.0.0.1,localhost"
+      ALLOWED_HOSTS: "127.0.0.1,localhost,46.62.139.177"
       CELERY_BROKER_URL: "redis://redis:6379/0"
       CELERY_RESULT_BACKEND: "redis://redis:6379/0"
       DB_ENGINE: "postgres"

--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -29,6 +29,8 @@ import EventNoteIcon from '@mui/icons-material/EventNote';
 
 const POLL_INTERVAL = 30000;
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+
 interface PaginatedResponse<T> {
   count: number;
   next: string | null;
@@ -143,7 +145,7 @@ const EventsPage: FC = () => {
 
 
   // Load a page of leads and their details
-  const loadLeads = async (url = 'http://localhost:8000/api/processed_leads/') => {
+  const loadLeads = async (url = `${API_BASE}/api/processed_leads/`) => {
     try {
       console.log('[loadLeads] request', url);
       const { data } = await axios.get<PaginatedResponse<ProcessedLead>>(url);
@@ -156,7 +158,7 @@ const EventsPage: FC = () => {
         data.results.map(l =>
           axios
             .get<Partial<LeadDetailType>>(
-              `http://localhost:8000/api/lead-details/${encodeURIComponent(l.lead_id)}/`
+              `${API_BASE}/api/lead-details/${encodeURIComponent(l.lead_id)}/`
             )
             .then(res => ({ ...res.data, lead_id: l.lead_id }))
             .catch(() => ({ lead_id: l.lead_id, user_display_name: '—' }))
@@ -177,7 +179,7 @@ const EventsPage: FC = () => {
   };
 
   // Load a page of events
-  const loadEvents = async (url = 'http://localhost:8000/api/lead-events/') => {
+  const loadEvents = async (url = `${API_BASE}/api/lead-events/`) => {
     try {
       console.log('[loadEvents] request', url);
       const { data } = await axios.get<PaginatedResponse<LeadEvent>>(url);
@@ -199,7 +201,7 @@ const EventsPage: FC = () => {
   const pollEvents = async () => {
     if (lastEventIdRef.current == null) return;
     try {
-      const url = `http://localhost:8000/api/lead-events?after_id=${lastEventIdRef.current}`;
+        const url = `${API_BASE}/api/lead-events?after_id=${lastEventIdRef.current}`;
       console.log('[pollEvents] request', url);
       const { data } = await axios.get<LeadEvent[]>(url);
       console.log('[pollEvents] received', data.length, 'events');


### PR DESCRIPTION
## Summary
- configure backend to use server OAuth callback and frontend URL
- allow Django container to accept the server IP
- use `REACT_APP_API_BASE_URL` in events page API calls

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648c5adf24832d944144f256cd9f07