### PR TITLE
Update API base URL defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ backend by setting the `REACT_APP_API_BASE_URL` environment variable:
 REACT_APP_API_BASE_URL=http://46.62.139.177:8000 npm run build
 ```
 
-If this variable is omitted, the app falls back to `http://localhost:8000/api`.
+If this variable is omitted, the app falls back to `http://46.62.139.177:8000/api`.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ const theme = createTheme({
 // Base URL for the API
 axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL
   ? `${process.env.REACT_APP_API_BASE_URL}/api`
-  : 'http://localhost:8000/api';
+  : 'http://46.62.139.177:8000/api';
 
 
 // ---------------------------------------------

--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -29,7 +29,7 @@ import EventNoteIcon from '@mui/icons-material/EventNote';
 
 const POLL_INTERVAL = 30000;
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://46.62.139.177:8000';
 
 interface PaginatedResponse<T> {
   count: number;

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -2,11 +2,12 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
+  const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://46.62.139.177:8000';
   // 1) Proxy to your Django backend
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://localhost:8000',
+      target: API_BASE,
       changeOrigin: true,
     })
   );


### PR DESCRIPTION
## Summary
- default frontend API calls to the deployed server
- update proxy middleware to use same default
- clarify README fallback address

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864908c9d1c832d96e3469a0e6296c9