### PR TITLE
Update lead handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ might appear in that first message. Events created after
 Phone numbers found in a lead's `additional_info` field also trigger the "real
 phone provided" flow when the lead is first processed.
 
-Before marking an incoming update as a new lead, the backend queries
-`/businesses/{business_id}/lead_ids` to check whether the ID has already been
-seen. Only when the ID is missing from this list is the event treated as
-`"NEW_LEAD"`.
+When a business account is authorized, the callback fetches
+`/businesses/{business_id}/lead_ids` for each connected business and stores the
+returned IDs in the local `ProcessedLead` table.
+
+During webhook processing the backend no longer queries Yelp. Instead it checks
+if the incoming `lead_id` exists in `ProcessedLead`. If not, the update is
+tagged as `"NEW_LEAD"` and the ID is saved so subsequent events are treated as
+already processed.
 
 ## Frontend API configuration
 

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -108,33 +108,8 @@ class WebhookView(APIView):
             if lid:
                 lead_ids.add(lid)
                 if upd.get("event_type") != "NEW_LEAD" and not ProcessedLead.objects.filter(lead_id=lid).exists():
-                    token = get_valid_business_token(payload["data"]["id"])
-                    url = f"https://api.yelp.com/v3/businesses/{payload['data']['id']}/lead_ids"
-                    try:
-                        resp = requests.get(
-                            url,
-                            headers={"Authorization": f"Bearer {token}"},
-                            timeout=10,
-                        )
-                    except Exception as exc:
-                        resp = None
-                        logger.warning(
-                            f"[WEBHOOK] Error fetching lead_ids for business={payload['data']['id']}: {exc}"
-                        )
-                    lead_list = (
-                        resp.json().get("lead_ids", []) if resp and resp.status_code == 200 else []
-                    )
-                    if resp is not None and resp.status_code != 200:
-                        logger.warning(
-                            f"[WEBHOOK] Lead ID check failed status={resp.status_code}"
-                        )
-                    if lid not in lead_list:
-                        upd["event_type"] = "NEW_LEAD"
-                        logger.info(f"[WEBHOOK] Marked lead={lid} as NEW_LEAD")
-                    else:
-                        logger.info(
-                            f"[WEBHOOK] Lead {lid} already present in Yelp list; not marking as NEW_LEAD"
-                        )
+                    upd["event_type"] = "NEW_LEAD"
+                    logger.info(f"[WEBHOOK] Marked lead={lid} as NEW_LEAD")
                 if upd.get("event_type") == "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT":
                     updated = LeadDetail.objects.filter(
                         lead_id=lid, phone_opt_in=False
@@ -172,11 +147,11 @@ class WebhookView(APIView):
         for upd in updates:
             if upd.get("event_type") == "NEW_LEAD":
                 lid = upd["lead_id"]
-                if not ProcessedLead.objects.filter(lead_id=lid).exists():
-                    pl = ProcessedLead.objects.create(
-                        business_id=payload["data"]["id"],
-                        lead_id=lid,
-                    )
+                pl, created = ProcessedLead.objects.get_or_create(
+                    business_id=payload["data"]["id"],
+                    lead_id=lid,
+                )
+                if created:
                     logger.info(f"[WEBHOOK] Created ProcessedLead id={pl.id} for lead={lid}")
                     logger.info(f"[WEBHOOK] Calling handle_new_lead for lead={lid}")
                     self.handle_new_lead(lid)


### PR DESCRIPTION
## Summary
- fetch existing lead IDs during Yelp OAuth callback
- mark updates as new leads by checking `ProcessedLead` table
- create `ProcessedLead` entries using `get_or_create`
- adjust tests for new behaviour
- document the new lead detection approach

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864c3ce7810832db4da6a34963b497b