### PR TITLE
Fix temporary email null constraint

### DIFF
--- a/backend/webhooks/migrations/0039_leaddetail_temp_email_nullable.py
+++ b/backend/webhooks/migrations/0039_leaddetail_temp_email_nullable.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0038_phone_available_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='leaddetail',
+            name='temporary_email_address',
+            field=models.EmailField(max_length=200, blank=True, null=True),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -229,7 +229,7 @@ class LeadDetail(models.Model):
     lead_id                        = models.CharField(max_length=64, unique=True, db_index=True)
     business_id                    = models.CharField(max_length=64)
     conversation_id                = models.CharField(max_length=64, blank=True)
-    temporary_email_address        = models.EmailField(max_length=200, blank=True)
+    temporary_email_address        = models.EmailField(max_length=200, blank=True, null=True)
     temporary_email_address_expiry = models.DateTimeField(null=True, blank=True)
     time_created                   = models.DateTimeField()
     last_event_time                = models.DateTimeField(null=True, blank=True)


### PR DESCRIPTION
## Summary
- make `temporary_email_address` nullable in the LeadDetail model
- add migration to update the database schema

## Testing
- `python manage.py makemigrations webhooks` *(fails: `ModuleNotFoundError: No module named 'django'`)*
- `pip install -r requirements.txt` *(fails: `Could not find a version that satisfies the requirement Django`)

------
https://chatgpt.com/codex/tasks/task_e_6864e5f52c74832db76cbf96f6daf5ec