### PR TITLE
Fix DataError saving OAuth lead events

### DIFF
--- a/backend/webhooks/migrations/0040_leadevent_cursor_textfield.py
+++ b/backend/webhooks/migrations/0040_leadevent_cursor_textfield.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0039_leaddetail_temp_email_nullable'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='leadevent',
+            name='cursor',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -215,7 +215,7 @@ class LeadEvent(models.Model):
     user_id           = models.CharField(max_length=64)
     user_display_name = models.CharField(max_length=100, blank=True)
     text              = models.TextField(blank=True)
-    cursor            = models.CharField(max_length=128, blank=True)
+    cursor            = models.TextField(blank=True)
     time_created      = models.DateTimeField()
     raw               = models.JSONField()
     created_at        = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
## Summary
- allow unlimited length for lead event cursors
- add migration to alter the cursor field

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864e81b21c0832d849c6f2c956d5ef9