### PR TITLE
Fix business filtering on events page

### DIFF
--- a/backend/webhooks/lead_views.py
+++ b/backend/webhooks/lead_views.py
@@ -115,15 +115,27 @@ class AutoResponseSettingsView(APIView):
 
 
 class ProcessedLeadListView(generics.ListAPIView):
-    queryset = ProcessedLead.objects.order_by("-processed_at")
     serializer_class = ProcessedLeadSerializer
     pagination_class = FivePerPagePagination
 
+    def get_queryset(self):
+        qs = ProcessedLead.objects.order_by("-processed_at")
+        bid = self.request.query_params.get("business_id")
+        if bid:
+            qs = qs.filter(business_id=bid)
+        return qs
+
 
 class LeadEventListAPIView(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = LeadEvent.objects.all().order_by("-id")
     serializer_class = LeadEventSerializer
     pagination_class = FivePerPagePagination
+
+    def get_queryset(self):
+        qs = LeadEvent.objects.all().order_by("-id")
+        bid = self.request.query_params.get("business_id")
+        if bid:
+            qs = qs.filter(business_id=bid)
+        return qs
 
     def get(self, request, *args, **kwargs):
         after_id = request.query_params.get("after_id")


### PR DESCRIPTION
## Summary
- filter ProcessedLead and LeadEvent lists by `business_id` in the API
- reload lists when business selection changes in the frontend
- include `business_id` when polling and loading more events/leads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f5f49d8c832d8e009ef30c8b7c6e