### PR TITLE
Fix EventsPage template string syntax

### DIFF
--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -210,8 +210,9 @@ const EventsPage: FC = () => {
   const pollEvents = async () => {
     if (lastEventIdRef.current == null) return;
     try {
-      const url = `${API_BASE}/api/lead-events?after_id=${lastEventIdRef.current}$
-{selectedBusiness ? `&business_id=${encodeURIComponent(selectedBusiness)}` : ''}`;
+      const url = `${API_BASE}/api/lead-events?after_id=${lastEventIdRef.current}${
+        selectedBusiness ? `&business_id=${encodeURIComponent(selectedBusiness)}` : ''
+      }`;
       console.log('[pollEvents] request', url);
       const { data } = await axios.get<LeadEvent[]>(url);
       console.log('[pollEvents] received', data.length, 'events');


### PR DESCRIPTION
## Summary
- correct template string used for poll events URL

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6864f7a8b9c0832d95eb635119d15c40