### PR TITLE
Fix LeadEvent filtering

### DIFF
--- a/backend/webhooks/lead_views.py
+++ b/backend/webhooks/lead_views.py
@@ -134,7 +134,12 @@ class LeadEventListAPIView(mixins.ListModelMixin, generics.GenericAPIView):
         qs = LeadEvent.objects.all().order_by("-id")
         bid = self.request.query_params.get("business_id")
         if bid:
-            qs = qs.filter(business_id=bid)
+            lead_ids = (
+                LeadDetail.objects
+                .filter(business_id=bid)
+                .values_list("lead_id", flat=True)
+            )
+            qs = qs.filter(lead_id__in=lead_ids)
         return qs
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary
- fix `LeadEventListAPIView` to resolve events for a business

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6864f91beee0832db9c7585095de6c5e