### PR TITLE
Add API check for new lead status

### DIFF
--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -132,7 +132,17 @@ class LeadIdVerificationTests(TestCase):
         events_resp = type(
             "E",
             (),
-            {"status_code": 200, "json": lambda self: {"events": []}},
+            {
+                "status_code": 200,
+                "json": lambda self: {
+                    "events": [
+                        {
+                            "id": "e0",
+                            "user_type": "CONSUMER",
+                        }
+                    ]
+                },
+            },
         )()
         mock_get.return_value = events_resp
         self._post()
@@ -148,7 +158,17 @@ class LeadIdVerificationTests(TestCase):
         events_resp = type(
             "E",
             (),
-            {"status_code": 200, "json": lambda self: {"events": []}},
+            {
+                "status_code": 200,
+                "json": lambda self: {
+                    "events": [
+                        {
+                            "id": "e0",
+                            "user_type": "CONSUMER",
+                        }
+                    ]
+                },
+            },
         )()
         mock_get.return_value = events_resp
         self._post()
@@ -163,25 +183,12 @@ class LeadIdVerificationTests(TestCase):
     def test_phone_in_additional_info_triggers_phone_available(
         self, mock_token, mock_new_lead, mock_phone_available, mock_cancel, mock_get
     ):
-        detail_resp = type(
-            "D",
-            (),
-            {
-                "status_code": 200,
-                "json": lambda self: {
-                    "business_id": self.biz_id,
-                    "project": {"additional_info": "+380111111111"},
-                    "user": {},
-                    "time_created": self.proc.processed_at.isoformat(),
-                },
-            },
-        )()
         events_resp = type(
             "E",
             (),
             {"status_code": 200, "json": lambda self: {"events": []}},
         )()
-        mock_get.side_effect = [detail_resp, events_resp, events_resp]
+        mock_get.side_effect = [events_resp, events_resp]
         self._post()
         mock_phone_available.assert_called_once()
         mock_cancel.assert_not_called()


### PR DESCRIPTION
## Summary
- verify potential new leads using Yelp events endpoint
- adjust webhook logic to mark lead as new only when the events API shows a single consumer message
- update unit tests for new lead verification logic

## Testing
- `pytest -q backend/webhooks/tests/test_webhook_events.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686504d976e4832d8aca585a87ae0928