### PR TITLE
Allow empty built-in follow-up

### DIFF
--- a/backend/webhooks/migrations/0041_follow_up_template_blank.py
+++ b/backend/webhooks/migrations/0041_follow_up_template_blank.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("webhooks", "0040_leadevent_cursor_textfield"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="autoresponsesettings",
+            name="follow_up_template",
+            field=models.TextField(
+                default="Just checking back in{sep}{name} — any questions about “{jobs}”?",
+                help_text="Шаблон follow-up повідомлення з плейсхолдерами {name}, {jobs}, {sep}",
+                blank=True,
+            ),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -29,13 +29,13 @@ class YelpOAuthState(models.Model):
 
 
 class YelpToken(models.Model):
-    business_id   = models.CharField(max_length=128, unique=True, db_index=True)
-    access_token  = EncryptedTextField()
+    business_id = models.CharField(max_length=128, unique=True, db_index=True)
+    access_token = EncryptedTextField()
     refresh_token = EncryptedTextField(null=True, blank=True)
-    expires_at    = models.DateTimeField(null=True, blank=True)
-    scopes        = models.TextField(null=True, blank=True)
-    created_at    = models.DateTimeField(auto_now_add=True)
-    updated_at    = models.DateTimeField(auto_now=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+    scopes = models.TextField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
 
 class YelpBusiness(models.Model):
@@ -72,27 +72,26 @@ class AutoResponseSettings(models.Model):
         help_text="Use these settings when phone number was provided in text",
     )
     enabled = models.BooleanField(
-        default=False,
-        help_text="Увімкнути/вимкнути автoвідповіді"
+        default=False, help_text="Увімкнути/вимкнути автoвідповіді"
     )
-    access_token     = EncryptedTextField(help_text="Yelp API access token")
-    refresh_token    = EncryptedTextField(blank=True,
-                                        help_text="Yelp API refresh token (дійсний 365 днів)")
-    token_expires_at = models.DateTimeField(null=True, blank=True,
-                                            help_text="Коли access_token перестане бути дійсним")
+    access_token = EncryptedTextField(help_text="Yelp API access token")
+    refresh_token = EncryptedTextField(
+        blank=True, help_text="Yelp API refresh token (дійсний 365 днів)"
+    )
+    token_expires_at = models.DateTimeField(
+        null=True, blank=True, help_text="Коли access_token перестане бути дійсним"
+    )
 
     # Вітальне повідомлення
     greeting_template = models.TextField(
         default="Hello{sep}{name}! Thank you for your inquiry regarding “{jobs}”.",
-        help_text="Шаблон першого повідомлення з плейсхолдерами {name}, {jobs}, {sep}"
+        help_text="Шаблон першого повідомлення з плейсхолдерами {name}, {jobs}, {sep}",
     )
     include_name = models.BooleanField(
-        default=True,
-        help_text="Включати ім’я клієнта у вітальне повідомлення"
+        default=True, help_text="Включати ім’я клієнта у вітальне повідомлення"
     )
     include_jobs = models.BooleanField(
-        default=True,
-        help_text="Включати список робіт у вітальне повідомлення"
+        default=True, help_text="Включати список робіт у вітальне повідомлення"
     )
 
     greeting_delay = models.PositiveIntegerField(
@@ -103,33 +102,32 @@ class AutoResponseSettings(models.Model):
     # Вбудований follow-up
     follow_up_template = models.TextField(
         default="Just checking back in{sep}{name} — any questions about “{jobs}”?",
-        help_text="Шаблон follow-up повідомлення з плейсхолдерами {name}, {jobs}, {sep}"
+        help_text="Шаблон follow-up повідомлення з плейсхолдерами {name}, {jobs}, {sep}",
+        blank=True,
     )
     follow_up_delay = models.PositiveIntegerField(
-        default=2,
-        help_text="Затримка перед follow-up, в секундах"
+        default=2, help_text="Затримка перед follow-up, в секундах"
     )
 
     export_to_sheets = models.BooleanField(
-        default=False,
-        help_text="Записувати нові ліди в Google Sheets"
+        default=False, help_text="Записувати нові ліди в Google Sheets"
     )
 
     greeting_open_from = models.TimeField(
         default=time(8, 0),
-        help_text="Час початку робочих годин для привітання (локальний час)"
+        help_text="Час початку робочих годин для привітання (локальний час)",
     )
     greeting_open_to = models.TimeField(
         default=time(20, 0),
-        help_text="Час завершення робочих годин для привітання (локальний час)"
+        help_text="Час завершення робочих годин для привітання (локальний час)",
     )
     follow_up_open_from = models.TimeField(
         default=time(8, 0),
-        help_text="Час початку робочих годин для built-in follow-up (локальний час)"
+        help_text="Час початку робочих годин для built-in follow-up (локальний час)",
     )
     follow_up_open_to = models.TimeField(
         default=time(20, 0),
-        help_text="Час завершення робочих годин для built-in follow-up (локальний час)"
+        help_text="Час завершення робочих годин для built-in follow-up (локальний час)",
     )
 
     def __str__(self):
@@ -152,19 +150,20 @@ class FollowUpTemplate(models.Model):
         default=False,
         help_text="Use this template when phone number was provided in text",
     )
-    name = models.CharField(
-        max_length=100,
-        help_text="Лаконічна назва шаблону"
-    )
+    name = models.CharField(max_length=100, help_text="Лаконічна назва шаблону")
     template = models.TextField(
         help_text='Текст з плейсхолдерами: "{name}", "{jobs}", "{sep}"'
     )
     delay = models.DurationField(
         default=timedelta(hours=24),
-        help_text="Затримка перед першим follow-up (наприклад, 24h)"
+        help_text="Затримка перед першим follow-up (наприклад, 24h)",
     )
-    open_from = models.TimeField(default=time(8,0), help_text="Час початку робочих годин (локальний час)")
-    open_to = models.TimeField(default=time(20,0), help_text="Час закінчення робочих годин (локальний час)")
+    open_from = models.TimeField(
+        default=time(8, 0), help_text="Час початку робочих годин (локальний час)"
+    )
+    open_to = models.TimeField(
+        default=time(20, 0), help_text="Час закінчення робочих годин (локальний час)"
+    )
     active = models.BooleanField(default=True)
 
     def __str__(self):
@@ -176,18 +175,16 @@ class ScheduledMessage(models.Model):
     template = models.ForeignKey(
         FollowUpTemplate,
         on_delete=models.CASCADE,
-        help_text="Який шаблон FollowUpTemplate використати"
+        help_text="Який шаблон FollowUpTemplate використати",
     )
-    next_run = models.DateTimeField(
-        help_text="Час наступного запуску повідомлення"
-    )
+    next_run = models.DateTimeField(help_text="Час наступного запуску повідомлення")
     active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def schedule_next(self):
         # Оновлюємо next_run згідно з delay із шаблону
         self.next_run = timezone.now() + self.template.delay
-        self.save(update_fields=['next_run'])
+        self.save(update_fields=["next_run"])
 
     def __str__(self):
         return f"#{self.pk} lead={self.lead_id} template={self.template.name} at {self.next_run}"
@@ -195,9 +192,7 @@ class ScheduledMessage(models.Model):
 
 class ScheduledMessageHistory(models.Model):
     scheduled = models.ForeignKey(
-        ScheduledMessage,
-        on_delete=models.CASCADE,
-        related_name='history'
+        ScheduledMessage, on_delete=models.CASCADE, related_name="history"
     )
     executed_at = models.DateTimeField(auto_now_add=True)
     status = models.CharField(max_length=16)  # 'success' або 'error'
@@ -208,73 +203,72 @@ class ScheduledMessageHistory(models.Model):
 
 
 class LeadEvent(models.Model):
-    event_id          = models.CharField(max_length=64, unique=True, db_index=True)
-    lead_id           = models.CharField(max_length=64, db_index=True)
-    event_type        = models.CharField(max_length=32)
-    user_type         = models.CharField(max_length=32)
-    user_id           = models.CharField(max_length=64)
+    event_id = models.CharField(max_length=64, unique=True, db_index=True)
+    lead_id = models.CharField(max_length=64, db_index=True)
+    event_type = models.CharField(max_length=32)
+    user_type = models.CharField(max_length=32)
+    user_id = models.CharField(max_length=64)
     user_display_name = models.CharField(max_length=100, blank=True)
-    text              = models.TextField(blank=True)
-    cursor            = models.TextField(blank=True)
-    time_created      = models.DateTimeField()
-    raw               = models.JSONField()
-    created_at        = models.DateTimeField(auto_now_add=True)
-    updated_at        = models.DateTimeField(auto_now=True)
+    text = models.TextField(blank=True)
+    cursor = models.TextField(blank=True)
+    time_created = models.DateTimeField()
+    raw = models.JSONField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f"{self.event_id} @ {self.lead_id}"
 
 
 class LeadDetail(models.Model):
-    lead_id                        = models.CharField(max_length=64, unique=True, db_index=True)
-    business_id                    = models.CharField(max_length=64)
-    conversation_id                = models.CharField(max_length=64, blank=True)
-    temporary_email_address        = models.EmailField(max_length=200, blank=True, null=True)
+    lead_id = models.CharField(max_length=64, unique=True, db_index=True)
+    business_id = models.CharField(max_length=64)
+    conversation_id = models.CharField(max_length=64, blank=True)
+    temporary_email_address = models.EmailField(max_length=200, blank=True, null=True)
     temporary_email_address_expiry = models.DateTimeField(null=True, blank=True)
-    time_created                   = models.DateTimeField()
-    last_event_time                = models.DateTimeField(null=True, blank=True)
-    user_display_name              = models.CharField(max_length=100, blank=True)
-    project                        = models.JSONField()
-    phone_opt_in                   = models.BooleanField(default=False)
-    phone_in_text                  = models.BooleanField(
+    time_created = models.DateTimeField()
+    last_event_time = models.DateTimeField(null=True, blank=True)
+    user_display_name = models.CharField(max_length=100, blank=True)
+    project = models.JSONField()
+    phone_opt_in = models.BooleanField(default=False)
+    phone_in_text = models.BooleanField(
         default=False,
         help_text="Consumer provided phone number inside a text message",
     )
-    phone_in_dialog                = models.BooleanField(
+    phone_in_dialog = models.BooleanField(
         default=False,
         help_text="Consumer provided phone number in reply to auto message",
     )
-    created_at                     = models.DateTimeField(auto_now_add=True)
-    updated_at                     = models.DateTimeField(auto_now=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f"LeadDetail({self.lead_id})"
 
+
 class LeadScheduledMessage(models.Model):
-    lead_id          = models.CharField(max_length=64, db_index=True)
-    content          = models.TextField(help_text="Текст повідомлення")
+    lead_id = models.CharField(max_length=64, db_index=True)
+    content = models.TextField(help_text="Текст повідомлення")
     interval_minutes = models.PositiveIntegerField(help_text="Інтервал у хвилинах")
-    next_run         = models.DateTimeField(help_text="Час наступного виконання")
-    active           = models.BooleanField(default=True)
-    created_at       = models.DateTimeField(auto_now_add=True)
+    next_run = models.DateTimeField(help_text="Час наступного виконання")
+    active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
 
     def schedule_next(self):
         self.next_run = timezone.now() + timedelta(minutes=self.interval_minutes)
-        self.save(update_fields=['next_run'])
+        self.save(update_fields=["next_run"])
 
     def __str__(self):
         return f"LeadScheduledMessage #{self.pk} to {self.lead_id} every {self.interval_minutes}min → {self.next_run}"
 
 
 class LeadScheduledMessageHistory(models.Model):
-    scheduled   = models.ForeignKey(
-        LeadScheduledMessage,
-        on_delete=models.CASCADE,
-        related_name='history'
+    scheduled = models.ForeignKey(
+        LeadScheduledMessage, on_delete=models.CASCADE, related_name="history"
     )
     executed_at = models.DateTimeField(auto_now_add=True)
-    status      = models.CharField(max_length=16, help_text="'success' або 'error'")
-    error       = models.TextField(blank=True, null=True, help_text="Текст помилки, якщо є")
+    status = models.CharField(max_length=16, help_text="'success' або 'error'")
+    error = models.TextField(blank=True, null=True, help_text="Текст помилки, якщо є")
 
     def __str__(self):
         return f"History #{self.pk} for msg {self.scheduled_id} at {self.executed_at}"

--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -31,6 +31,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Chip,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
@@ -882,7 +883,17 @@ const AutoResponseSettings: FC = () => {
 
             {/* Built-in Follow-up */}
             <Box>
-              <Typography variant="h6">Built-in Follow-up</Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <Typography variant="h6">Built-in Follow-up</Typography>
+                {!followUpTemplate.trim() && (
+                  <Chip
+                    label="Field is inactive"
+                    color="error"
+                    size="small"
+                    sx={{ ml: 1 }}
+                  />
+                )}
+              </Box>
               <Stack direction="row" spacing={1} mb={1}>
                 {PLACEHOLDERS.map(ph => (
                   <Button key={ph} size="small" variant="outlined"

--- a/frontend/src/SettingsTemplates.tsx
+++ b/frontend/src/SettingsTemplates.tsx
@@ -19,6 +19,7 @@ import {
   Box,
   Snackbar,
   Alert,
+  Chip,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
@@ -348,6 +349,14 @@ const SettingsTemplates: React.FC = () => {
                 </Button>
               ))}
             </Stack>
+            {!data.follow_up_template.trim() && (
+              <Chip
+                label="Field is inactive"
+                color="error"
+                size="small"
+                sx={{ mb: 1 }}
+              />
+            )}
             <TextField
               inputRef={followRef}
               multiline


### PR DESCRIPTION
## Summary
- allow blank follow_up_template in AutoResponseSettings
- expose field as optional in serializer
- highlight inactive follow up with red chip in settings pages
- migration for model change

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68650cd8fe2c832d8b303ec51f2af083