### PR TITLE
Improve error diagnostics for Yelp token usage

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -333,9 +333,14 @@ class WebhookView(APIView):
 
         detail_url = f"https://api.yelp.com/v3/leads/{lead_id}"
         headers = {"Authorization": f"Bearer {token}"}
+        logger.debug(
+            f"[AUTO-RESPONSE] Fetching lead details from {detail_url} using token ending ...{token[-4:]}"
+        )
         resp = requests.get(detail_url, headers=headers, timeout=10)
         if resp.status_code != 200:
-            logger.error(f"[AUTO-RESPONSE] DETAIL ERROR lead={lead_id}, status={resp.status_code}")
+            logger.error(
+                f"[AUTO-RESPONSE] DETAIL ERROR lead={lead_id}, status={resp.status_code}, body={resp.text}"
+            )
             return
         d = resp.json()
 


### PR DESCRIPTION
## Summary
- add debug logs when refreshing global Yelp token and for business token operations
- log token usage and response body when fetching lead details to pinpoint 403 errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6865923cd05c832da0e50c97e68ef16e