### PR TITLE
Improve token logging and make encryption optional

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -213,6 +213,8 @@ YELP_OAUTH_SCOPES = [
 ]
 YELP_API_KEY = os.getenv("YELP_API_KEY", "KTqXwkcW5t4EwUN-8SusEfrSfctwVDIJ65FXXR3T72xYS-ZEuKORWvtvT1OQ8zBIcCXsP7nyrcXFuL_93988JoPpezu1Or4mE25_tSA8zVKji_4NI6_EbHJMbOYRZHYx")
 YELP_TOKEN_SECRET = os.getenv("YELP_TOKEN_SECRET", "0123456789ABCDEF0123456789ABCDEF")
+# When true, tokens are stored and logged in plain text without encryption
+DISABLE_TOKEN_ENCRYPTION = os.getenv("DISABLE_TOKEN_ENCRYPTION", "false").lower() in ("1", "true", "yes")
 GOOGLE_TIMEZONE_API_KEY = os.getenv("GOOGLE_TIMEZONE_API_KEY", "AIzaSyC3TB24rn-fp7IJ2m_T3PyMKLXuDSNOL9k")
 
 # Frontend URL

--- a/backend/webhooks/fields.py
+++ b/backend/webhooks/fields.py
@@ -36,7 +36,7 @@ class EncryptedTextField(models.TextField):
     """TextField that encrypts values using Fernet."""
 
     def from_db_value(self, value, expression, connection):
-        if value is None:
+        if value is None or settings.DISABLE_TOKEN_ENCRYPTION:
             return value
         f = get_fernet()
         try:
@@ -46,7 +46,7 @@ class EncryptedTextField(models.TextField):
             return value
 
     def get_prep_value(self, value):
-        if value is None:
+        if value is None or settings.DISABLE_TOKEN_ENCRYPTION:
             return value
         f = get_fernet()
         return f.encrypt(str(value).encode()).decode()

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -196,7 +196,7 @@ class WebhookView(APIView):
         for lid in lead_ids:
             token = get_valid_business_token(biz_id)
             logger.info(
-                f"[WEBHOOK] Using business token for lead={lid} ending ...{token[-4:]}"
+                f"[WEBHOOK] Using business token for lead={lid}: {token}"
             )
             url = f"https://api.yelp.com/v3/leads/{lid}/events"
             params = {"limit": 20}
@@ -325,8 +325,12 @@ class WebhookView(APIView):
                 phone_available=phone_available,
             ).first()
             token = get_valid_business_token(pl.business_id)
+            logger.debug(
+                f"[AUTO-RESPONSE] Obtained business token for {pl.business_id}: {token}"
+            )
         else:
             token = get_valid_yelp_token()
+            logger.debug("[AUTO-RESPONSE] Obtained global token: %s", token)
 
         auto_settings = biz_settings if biz_settings is not None else default_settings
         if auto_settings is None:
@@ -335,7 +339,7 @@ class WebhookView(APIView):
         detail_url = f"https://api.yelp.com/v3/leads/{lead_id}"
         headers = {"Authorization": f"Bearer {token}"}
         logger.debug(
-            f"[AUTO-RESPONSE] Fetching lead details from {detail_url} using token ending ...{token[-4:]}"
+            f"[AUTO-RESPONSE] Fetching lead details from {detail_url} using token {token}"
         )
         resp = requests.get(detail_url, headers=headers, timeout=10)
         if resp.status_code != 200:


### PR DESCRIPTION
## Summary
- add `DISABLE_TOKEN_ENCRYPTION` setting and update `EncryptedTextField`
- log tokens in full and show the source of each token
- expose obtained tokens in webhook debug logs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6865b491aba0832dbafc8d5900145493