### PR TITLE
Disable token encryption by default

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -11,6 +11,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 import os
 
+# Default to plain-text storage of tokens unless explicitly overridden
+os.environ.setdefault("DISABLE_TOKEN_ENCRYPTION", "true")
+
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
## Summary
- ensure the backend stores tokens in plain text if the environment variable is unset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6865bd2c15dc832db7b66fcd07af7b1c