### PR TITLE
Improve webhook error logging

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -343,8 +343,10 @@ class WebhookView(APIView):
         )
         resp = requests.get(detail_url, headers=headers, timeout=10)
         if resp.status_code != 200:
+            source = f"business {pl.business_id}" if pl else "global token"
             logger.error(
-                f"[AUTO-RESPONSE] DETAIL ERROR lead={lead_id}, status={resp.status_code}, body={resp.text}"
+                f"[AUTO-RESPONSE] DETAIL ERROR lead={lead_id}, business_id={pl.business_id if pl else 'N/A'}, "
+                f"token_source={source}, token={token}, status={resp.status_code}, body={resp.text}"
             )
             return
         d = resp.json()


### PR DESCRIPTION
## Summary
- log the token source and business ID when Yelp returns NO_BUSINESS_ACCESS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68663ecd50ac832db60e2189f50a44b3