### PR TITLE
Remove global token usage

### DIFF
--- a/backend/webhooks/migrations/0043_remove_autoresponse_tokens.py
+++ b/backend/webhooks/migrations/0043_remove_autoresponse_tokens.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0042_autoresponsesettings_off_hours_template'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='autoresponsesettings',
+            name='access_token',
+        ),
+        migrations.RemoveField(
+            model_name='autoresponsesettings',
+            name='refresh_token',
+        ),
+        migrations.RemoveField(
+            model_name='autoresponsesettings',
+            name='token_expires_at',
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -74,13 +74,6 @@ class AutoResponseSettings(models.Model):
     enabled = models.BooleanField(
         default=False, help_text="Увімкнути/вимкнути автoвідповіді"
     )
-    access_token = EncryptedTextField(help_text="Yelp API access token")
-    refresh_token = EncryptedTextField(
-        blank=True, help_text="Yelp API refresh token (дійсний 365 днів)"
-    )
-    token_expires_at = models.DateTimeField(
-        null=True, blank=True, help_text="Коли access_token перестане бути дійсним"
-    )
 
     # Вітальне повідомлення
     greeting_template = models.TextField(

--- a/backend/webhooks/oauth_views.py
+++ b/backend/webhooks/oauth_views.py
@@ -16,7 +16,6 @@ from rest_framework.decorators import api_view
 
 from .models import (
     YelpOAuthState,
-    AutoResponseSettings,
     YelpToken,
     YelpBusiness,
     ProcessedLead,
@@ -198,12 +197,6 @@ class YelpAuthCallbackView(APIView):
             if not access_token:
                 return redirect(f"{settings.FRONTEND_URL}/callback?error=token_error")
 
-            settings_obj, _ = AutoResponseSettings.objects.get_or_create(id=1)
-            settings_obj.access_token = access_token
-            settings_obj.refresh_token = refresh_token or settings_obj.refresh_token
-            settings_obj.token_expires_at = timezone.now() + timedelta(seconds=expires_in)
-            settings_obj.enabled = True
-            settings_obj.save()
 
             biz_resp = requests.get(
                 "https://partner-api.yelp.com/token/v1/businesses",

--- a/backend/webhooks/proxy_views.py
+++ b/backend/webhooks/proxy_views.py
@@ -7,7 +7,6 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 
 from .utils import (
-    get_valid_yelp_token,
     get_valid_business_token,
     get_token_for_lead,
 )
@@ -22,6 +21,8 @@ class LeadEventsProxyView(APIView):
 
     def get(self, request, lead_id):
         token = get_token_for_lead(lead_id)
+        if not token:
+            return Response({"detail": "unknown business"}, status=400)
         url = f"https://api.yelp.com/v3/leads/{lead_id}/events"
         headers = {"Authorization": f"Bearer {token}"}
         params = {"limit": request.query_params.get("limit", 20)}
@@ -52,6 +53,8 @@ class LeadEventsProxyView(APIView):
 
     def post(self, request, lead_id):
         token = get_token_for_lead(lead_id)
+        if not token:
+            return Response({"detail": "unknown business"}, status=400)
         url = f"https://api.yelp.com/v3/leads/{lead_id}/events"
         headers = {
             "Authorization": f"Bearer {token}",
@@ -108,6 +111,8 @@ class LeadDetailProxyView(APIView):
 
     def get(self, request, lead_id):
         token = get_token_for_lead(lead_id)
+        if not token:
+            return Response({"detail": "unknown business"}, status=400)
         url = f"https://api.yelp.com/v3/leads/{lead_id}"
         headers = {"Authorization": f"Bearer {token}"}
         resp = requests.get(url, headers=headers)
@@ -177,6 +182,8 @@ class AttachmentProxyView(APIView):
 
     def get(self, request, lead_id: str, attachment_id: str):
         token = get_token_for_lead(lead_id)
+        if not token:
+            return Response({"detail": "unknown business"}, status=400)
         url = f"https://api.yelp.com/v3/leads/{lead_id}/attachments/{attachment_id}"
         headers = {"Authorization": f"Bearer {token}"}
 

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -39,9 +39,6 @@ class AutoResponseSettingsSerializer(serializers.ModelSerializer):
             "phone_opt_in",
             "phone_available",
             "enabled",
-            "access_token",
-            "refresh_token",
-            "token_expires_at",
             "greeting_template",
             "greeting_off_hours_template",
             "greeting_delay",
@@ -55,7 +52,7 @@ class AutoResponseSettingsSerializer(serializers.ModelSerializer):
             "follow_up_open_to",
             "export_to_sheets",
         ]
-        read_only_fields = ["id", "token_expires_at"]
+        read_only_fields = ["id"]
 
     def create(self, validated_data):
         business_id = (

--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -15,7 +15,6 @@ from .models import (
     YelpToken,
 )
 from .utils import (
-    get_valid_yelp_token,
     get_token_for_lead,
     rotate_refresh_token,
 )

--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -249,8 +249,6 @@ class AutoResponseDisabledTests(TestCase):
             phone_opt_in=False,
             phone_available=False,
             enabled=False,
-            access_token="a",
-            refresh_token="r",
         )
 
     @patch("webhooks.webhook_views.send_scheduled_message.apply_async")


### PR DESCRIPTION
## Summary
- delete global token fields from AutoResponseSettings
- fetch lead tokens strictly from YelpToken
- remove fallback to a global token in webhook and proxy views
- clean up OAuth callback and serializers
- adjust tests for new model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68665d831a64832d9b4b438d99d2a698