### PR TITLE
Translate working hours labels

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -828,7 +828,7 @@ const AutoResponseSettings: FC = () => {
             {/* Greeting */}
             <Box>
               <Typography variant="h6">
-                {phoneAvailable ? 'Greeting Message (робочі години)' : 'Greeting Message'}
+                {phoneAvailable ? 'Greeting Message (Business Hours)' : 'Greeting Message'}
               </Typography>
               <Stack direction="row" spacing={1} mb={1}>
                 {PLACEHOLDERS.map(ph => (
@@ -907,7 +907,7 @@ const AutoResponseSettings: FC = () => {
 
             {phoneAvailable && (
               <Box>
-                <Typography variant="h6">Greeting Message (не робочі години)</Typography>
+              <Typography variant="h6">Greeting Message (Off Hours)</Typography>
                 <Stack direction="row" spacing={1} mb={1}>
                   {PLACEHOLDERS.map(ph => (
                     <Button key={ph} size="small" variant="outlined" onClick={() => insertPlaceholder(ph, 'after')}>


### PR DESCRIPTION
## Summary
- update business hours strings to English in auto-response settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found and network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68666ab62444832da132004d82dbe6b7