### PR TITLE
Add phone_in_additional_info flag

### DIFF
--- a/backend/webhooks/migrations/0044_leaddetail_phone_in_additional_info.py
+++ b/backend/webhooks/migrations/0044_leaddetail_phone_in_additional_info.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0043_remove_autoresponse_tokens'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='leaddetail',
+            name='phone_in_additional_info',
+            field=models.BooleanField(default=False, help_text='Consumer provided phone number inside additional_info'),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -233,6 +233,10 @@ class LeadDetail(models.Model):
         default=False,
         help_text="Consumer provided phone number inside a text message",
     )
+    phone_in_additional_info = models.BooleanField(
+        default=False,
+        help_text="Consumer provided phone number inside additional_info",
+    )
     phone_in_dialog = models.BooleanField(
         default=False,
         help_text="Consumer provided phone number in reply to auto message",

--- a/backend/webhooks/serializers.py
+++ b/backend/webhooks/serializers.py
@@ -232,7 +232,7 @@ class LeadDetailSerializer(serializers.ModelSerializer):
             "project",
             "phone_opt_in",
             "phone_in_text",
-            "phone_in_dialog",
+            "phone_in_additional_info",
             "created_at",
             "updated_at",
         ]

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -408,9 +408,9 @@ class WebhookView(APIView):
             not phone_available
             and PHONE_RE.search(detail_data["project"].get("additional_info", ""))
         ):
-            if not ld.phone_in_text:
-                ld.phone_in_text = True
-                ld.save(update_fields=["phone_in_text"])
+            if not ld.phone_in_additional_info:
+                ld.phone_in_additional_info = True
+                ld.save(update_fields=["phone_in_additional_info"])
             logger.info("[AUTO-RESPONSE] Phone found in additional_info")
             self.handle_phone_available(
                 lead_id, reason="phone number found in additional_info"

--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -98,8 +98,12 @@ const NewEvents: FC<Props> = ({
                 {detail?.phone_in_text && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
-                {detail?.phone_in_dialog && (
-                  <Chip label="Phone in dialog" color="info" size="small" />
+                {detail?.phone_in_additional_info && (
+                  <Chip
+                    label="Telephone in additional info"
+                    color="info"
+                    size="small"
+                  />
                 )}
 
                 {e.event_type && (

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -157,8 +157,12 @@ const NewLeads: FC<Props> = ({
                 {detail.phone_in_text && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
-                {detail.phone_in_dialog && (
-                  <Chip label="Phone in dialog" color="info" size="small" />
+                {detail.phone_in_additional_info && (
+                  <Chip
+                    label="Telephone in additional info"
+                    color="info"
+                    size="small"
+                  />
                 )}
 
                 {/* Buttons */}

--- a/frontend/src/EventsPage/types.ts
+++ b/frontend/src/EventsPage/types.ts
@@ -52,7 +52,7 @@ export interface LeadDetail {
   };
   phone_opt_in?: boolean;
   phone_in_text?: boolean;
-  phone_in_dialog?: boolean;
+  phone_in_additional_info?: boolean;
   created_at?: string;
   updated_at?: string;
   // Add other fields here if needed


### PR DESCRIPTION
## Summary
- record when phone number is provided in `additional_info`
- expose new `phone_in_additional_info` field via API
- display "Telephone in additional info" badge in UI
- remove `Phone in dialog` badge from UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667dbe45c4832d9ef64cabb7321e71