### PR TITLE
Update celery task logging

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -12,6 +12,7 @@ from celery.signals import (
 from django.db import transaction
 from django.utils import timezone
 from django.apps import apps
+from webhooks.models import LeadPendingTask
 
 # Fallback UTC constant for older Django versions without timezone.utc
 UTC = getattr(timezone, "utc", dt_timezone.utc)
@@ -121,6 +122,8 @@ def log_task_start(sender=None, task_id=None, args=None, kwargs=None, **other):
             started_at=timezone.now(),
             status="STARTED",
         )
+
+    LeadPendingTask.objects.filter(task_id=task_id).update(active=False)
 
 
 @task_postrun.connect

--- a/backend/webhooks/tests/test_celery_signals.py
+++ b/backend/webhooks/tests/test_celery_signals.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from config.celery import app
+from webhooks.models import LeadPendingTask
+import uuid
+
+
+class CelerySignalTests(TestCase):
+    def test_task_start_marks_pending_inactive(self):
+        @app.task
+        def dummy():
+            return "ok"
+
+        app.conf.task_always_eager = True
+        tid = str(uuid.uuid4())
+        LeadPendingTask.objects.create(lead_id="l", task_id=tid, phone_opt_in=False)
+
+        dummy.apply(task_id=tid)
+
+        pending = LeadPendingTask.objects.get(task_id=tid)
+        self.assertFalse(pending.active)


### PR DESCRIPTION
## Summary
- mark LeadPendingTask inactive when Celery task actually starts
- add unit test verifying the signal behaviour

## Testing
- `python backend/manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686695325fd0832d95a612bc73faa43a