### PR TITLE
Add simple frontend login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Routes,
   Route,
   Link as RouterLink,
+  Navigate,
 } from 'react-router-dom';
 
 // --- Material-UI Imports ---
@@ -48,6 +49,7 @@ import TokenStatus from "./TokenStatus";
 import TaskLogs from "./TaskLogs";
 import SettingsTemplates from "./SettingsTemplates";
 import Subscriptions from "./Subscriptions";
+import LoginPage from "./LoginPage";
 
 // A default theme for the application
 const theme = createTheme({
@@ -74,12 +76,32 @@ const drawerWidth = 240;
 
 const App: FC = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [authenticated, setAuthenticated] = useState(
+    localStorage.getItem('isAuthenticated') === 'true'
+  );
   const themeHook = useTheme();
   const isMobile = useMediaQuery(themeHook.breakpoints.down('sm'));
 
   const handleDrawerToggle = () => {
     setMobileOpen(prev => !prev);
   };
+
+  if (!authenticated) {
+    return (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Router>
+          <Routes>
+            <Route
+              path="/login"
+              element={<LoginPage onLogin={() => setAuthenticated(true)} />}
+            />
+            <Route path="*" element={<Navigate to="/login" replace />} />
+          </Routes>
+        </Router>
+      </ThemeProvider>
+    );
+  }
 
   const drawer = (
     <div>
@@ -162,9 +184,18 @@ const App: FC = () => {
                   <MenuIcon />
                 </IconButton>
               )}
-              <Typography variant="h6" noWrap component="div">
+              <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
                 Yelp Integration Dashboard
               </Typography>
+              <Button
+                color="inherit"
+                onClick={() => {
+                  localStorage.removeItem('isAuthenticated');
+                  setAuthenticated(false);
+                }}
+              >
+                Logout
+              </Button>
             </Toolbar>
           </AppBar>
 

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,0 +1,62 @@
+import React, { FC, useState } from 'react';
+import { Container, Paper, TextField, Button, Typography, Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  onLogin: () => void;
+}
+
+const LoginPage: FC<Props> = ({ onLogin }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username === 'yelp admin' && password === 'GAndmPrQgVDVGdnQG') {
+      localStorage.setItem('isAuthenticated', 'true');
+      onLogin();
+      navigate('/');
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <Container maxWidth="xs" sx={{ mt: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Typography variant="h5" component="h1" align="center" gutterBottom>
+          Login
+        </Typography>
+        {error && (
+          <Typography color="error" variant="body2" sx={{ mb: 1 }}>
+            {error}
+          </Typography>
+        )}
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField
+            label="Username"
+            fullWidth
+            margin="normal"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+          <TextField
+            label="Password"
+            type="password"
+            fullWidth
+            margin="normal"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Log in
+          </Button>
+        </Box>
+      </Paper>
+    </Container>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
## Summary
- add LoginPage component with hard-coded credentials
- guard the main app behind the login page
- allow logout via button in the top bar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9f08d1c832da63fc35123e7fc09