### PR TITLE
Adjust phone indicators

### DIFF
--- a/frontend/src/EventsPage/NewEvents.tsx
+++ b/frontend/src/EventsPage/NewEvents.tsx
@@ -95,7 +95,7 @@ const NewEvents: FC<Props> = ({
                 {detail?.phone_opt_in && (
                   <Chip label="Phone Opt-In" color="success" size="small" />
                 )}
-                {detail?.phone_in_text && (
+                {detail?.phone_in_text && !detail?.phone_in_additional_info && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
                 {detail?.phone_in_additional_info && (

--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -154,7 +154,7 @@ const NewLeads: FC<Props> = ({
                 {detail.phone_opt_in && (
                   <Chip label="Phone Opt-In" color="success" size="small" />
                 )}
-                {detail.phone_in_text && (
+                {detail.phone_in_text && !detail.phone_in_additional_info && (
                   <Chip label="Phone in text" color="info" size="small" />
                 )}
                 {detail.phone_in_additional_info && (


### PR DESCRIPTION
## Summary
- show 'Phone in text' only when a phone number is not already flagged in additional info

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc5d7a1c832d9a57efeec2ae6720