### PR TITLE
Export phone opt-in to Google Sheets

### DIFF
--- a/backend/webhooks/oauth_views.py
+++ b/backend/webhooks/oauth_views.py
@@ -73,6 +73,7 @@ def fetch_and_store_lead(access_token: str, lead_id: str) -> None:
             "last_event_time": last_time,
             "user_display_name": detail.get("user", {}).get("display_name", ""),
             "phone_number": phone_number,
+            "phone_opt_in": detail.get("phone_opt_in", False),
             "project": {
                 "survey_answers": survey_list,
                 "location": raw_proj.get("location", {}),

--- a/backend/webhooks/utils.py
+++ b/backend/webhooks/utils.py
@@ -249,6 +249,7 @@ def append_lead_to_sheet(detail_data: dict):
             _format_location(proj.get("location", {})),
             detail_data.get("phone_number", ""),
             _format_attachments(proj.get("attachments", [])),
+            detail_data.get("phone_opt_in", False),
         ]
 
         # Use USER_ENTERED so formulas like HYPERLINK() are parsed correctly

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -422,6 +422,7 @@ class WebhookView(APIView):
             "last_event_time": last_time,
             "user_display_name": d.get("user", {}).get("display_name", ""),
             "phone_number": phone_number,
+            "phone_opt_in": d.get("phone_opt_in", False),
             "project": {
                 "survey_answers": survey_list,
                 "location": raw_proj.get("location", {}),


### PR DESCRIPTION
## Summary
- include `phone_opt_in` when saving lead details
- add phone opt-in column in Sheets export

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cf38bee10832da8759c89b670d738