### PR TITLE
Shorten token refresh interval

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -69,7 +69,7 @@ LOGGING = {
         # ваш додаток
         'webhooks': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': 'DEBUG',
             'propagate': False,
         },
         # щоб також бачити запити DRF, можна ввімкнути
@@ -248,6 +248,6 @@ CELERY_BEAT_SCHEDULE = {
     },
     'refresh-yelp-tokens': {
         'task': 'webhooks.tasks.refresh_expiring_tokens',
-        'schedule': 1800.0,
+        'schedule': 300.0,
     },
 }


### PR DESCRIPTION
## Summary
- refresh Yelp tokens every 5 minutes instead of every 30
- raise `webhooks` logger level to DEBUG for verbose output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6870dde57228832d926d9fd3772ecf77