### PR TITLE
Sync tokens sharing refresh code

### DIFF
--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -18,6 +18,7 @@ from .utils import (
     get_token_for_lead,
     get_valid_business_token,
     rotate_refresh_token,
+    update_shared_refresh_token,
 )
 
 logger = logging.getLogger(__name__)
@@ -262,7 +263,9 @@ def refresh_expiring_tokens():
     for tok in tokens:
         logger.info(f"[TOKEN REFRESH] Attempting refresh for {tok.business_id}")
         try:
-            data = rotate_refresh_token(tok.refresh_token)
+            old_refresh = tok.refresh_token
+            data = rotate_refresh_token(old_refresh)
+            update_shared_refresh_token(old_refresh, data)
             tok.access_token = data["access_token"]
             tok.refresh_token = data.get("refresh_token", tok.refresh_token)
             exp = data.get("expires_in")

--- a/backend/webhooks/tests/test_token_refresh.py
+++ b/backend/webhooks/tests/test_token_refresh.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from unittest.mock import patch
+from django.utils import timezone
+
+from webhooks.models import YelpToken
+from webhooks.utils import get_valid_business_token
+from webhooks.tasks import refresh_expiring_tokens
+from config.celery import app
+
+
+class TokenRefreshSyncTests(TestCase):
+    def setUp(self):
+        self.old_refresh = "r1"
+        expired = timezone.now() - timezone.timedelta(seconds=5)
+        YelpToken.objects.create(
+            business_id="b1", access_token="a1", refresh_token=self.old_refresh, expires_at=expired
+        )
+        YelpToken.objects.create(
+            business_id="b2", access_token="a2", refresh_token=self.old_refresh, expires_at=expired
+        )
+
+    @patch("webhooks.utils.rotate_refresh_token")
+    def test_get_valid_updates_all_shared(self, mock_rotate):
+        mock_rotate.return_value = {
+            "access_token": "new",
+            "refresh_token": "r2",
+            "expires_in": 3600,
+        }
+        token = get_valid_business_token("b1")
+        self.assertEqual(token, "new")
+        b1 = YelpToken.objects.get(business_id="b1")
+        b2 = YelpToken.objects.get(business_id="b2")
+        self.assertEqual(b1.access_token, "new")
+        self.assertEqual(b2.access_token, "new")
+        self.assertEqual(b1.refresh_token, "r2")
+        self.assertEqual(b2.refresh_token, "r2")
+        self.assertIsNotNone(b2.expires_at)
+
+    @patch("webhooks.tasks.rotate_refresh_token")
+    def test_task_refresh_updates_all_shared(self, mock_rotate):
+        app.conf.task_always_eager = True
+        soon = timezone.now() + timezone.timedelta(seconds=1)
+        YelpToken.objects.all().update(expires_at=soon)
+        mock_rotate.return_value = {
+            "access_token": "task",
+            "refresh_token": "r3",
+            "expires_in": 7200,
+        }
+        refresh_expiring_tokens.delay()
+        b1 = YelpToken.objects.get(business_id="b1")
+        b2 = YelpToken.objects.get(business_id="b2")
+        self.assertEqual(b1.access_token, "task")
+        self.assertEqual(b2.access_token, "task")
+        self.assertEqual(b1.refresh_token, "r3")
+        self.assertEqual(b2.refresh_token, "r3")
+        self.assertIsNotNone(b1.expires_at)
+


### PR DESCRIPTION
## Summary
- add `update_shared_refresh_token` helper to update all tokens using the same refresh token
- call helper when refreshing tokens in `get_valid_business_token` and in the token refresh task
- ensure tokens stay synchronized by testing refresh logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6870ed79fda8832d9766da218b5b87b6