### PR TITLE
Persist celery tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ the Postgres port in `backend/docker-compose.yml`:
 Restart the stack with `docker compose up -d`. The database is then available
 at `localhost:5433` with the credentials listed above.
 
+## Persisting Celery tasks
+
+Celery uses Redis to queue background jobs. If the stack is restarted and Redis
+is not configured with a volume, any scheduled tasks are lost. The
+`redis` service in `backend/docker-compose.yml` now mounts the named volume
+`redis_data` so Celery's queue survives container restarts:
+
+```yaml
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  redis_data:
+```
+
+After updating the compose file, run `docker compose up -d` again to apply the
+changes. Scheduled tasks and other Redis data will persist between restarts.
+
 ## Webhook event processing
 
 When events are fetched from Yelp after a lead is created, the backend ignores

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -33,6 +33,8 @@ services:
   redis:
     image: redis:7
     restart: unless-stopped
+    volumes:
+      - redis_data:/data
 
   db:
     image: postgres:16
@@ -91,4 +93,5 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
 


### PR DESCRIPTION
## Summary
- mount a redis_data volume to keep Celery queue after restart
- document the new volume in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687288e14458832d84bea748073d5ce0