### PR TITLE
Add ScheduledMessage uniqueness guard

### DIFF
--- a/backend/webhooks/migrations/0046_scheduledmessage_unique.py
+++ b/backend/webhooks/migrations/0046_scheduledmessage_unique.py
@@ -1,0 +1,13 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0045_leaddetail_phone_number'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='scheduledmessage',
+            constraint=models.UniqueConstraint(fields=['lead_id', 'template'], name='uniq_lead_template'),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -179,6 +179,14 @@ class ScheduledMessage(models.Model):
     active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["lead_id", "template"],
+                name="uniq_lead_template",
+            )
+        ]
+
     def schedule_next(self):
         # Оновлюємо next_run згідно з delay із шаблону
         self.next_run = timezone.now() + self.template.delay

--- a/backend/webhooks/tests/test_unique_constraints.py
+++ b/backend/webhooks/tests/test_unique_constraints.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.db import IntegrityError
+from django.utils import timezone
+
+from webhooks.models import ScheduledMessage, FollowUpTemplate
+
+
+class ScheduledMessageUniqueConstraintTests(TestCase):
+    def test_unique_lead_template_constraint(self):
+        tpl = FollowUpTemplate.objects.create(name='tpl', template='hi')
+        ScheduledMessage.objects.create(
+            lead_id='l1',
+            template=tpl,
+            next_run=timezone.now(),
+        )
+        with self.assertRaises(IntegrityError):
+            ScheduledMessage.objects.create(
+                lead_id='l1',
+                template=tpl,
+                next_run=timezone.now(),
+            )


### PR DESCRIPTION
## Summary
- ensure combination of `lead_id` and follow-up template is unique
- add migration for new constraint
- test the unique constraint logic

## Testing
- `python manage.py test webhooks.tests.test_unique_constraints` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68728f80cd64832dbead8dcea3552a08