### PR TITLE
Add structured logging and centralized shipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ Thumbs.db
 google-credentials.json
 *.key
 *.pem
-"backend/service_account.json" 
+backend/logs/
+"backend/service_account.json"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       - .:/app
     ports:
       - "8000:8000"
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
@@ -66,6 +70,10 @@ services:
       POSTGRES_DB: "postgres"
     volumes:
       - .:/app
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
@@ -87,9 +95,30 @@ services:
       POSTGRES_DB: "postgres"
     volumes:
       - .:/app
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
+
+  loki:
+    image: grafana/loki:2.9.5
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail:
+    image: grafana/promtail:2.9.5
+    restart: unless-stopped
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/docker-config.yaml
+    depends_on:
+      - loki
 
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ cryptography
 django-filter
 psycopg2-binary
 
+python-json-logger
+sentry-sdk[django]
+


### PR DESCRIPTION
## Summary
- ignore backend log output
- configure rotating JSON logging and Sentry
- send logs to stdout for Docker
- add Loki and Promtail services in compose and route container logs via Loki driver
- include logging dependencies

## Testing
- `python -m py_compile backend/config/settings.py`
- `pip install -q -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872ac88fe18832da2e6b57780ad5d9b