### PR TITLE
Add unique constraint for LeadScheduledMessage

### DIFF
--- a/backend/webhooks/migrations/0047_leadscheduledmessage_unique.py
+++ b/backend/webhooks/migrations/0047_leadscheduledmessage_unique.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('webhooks', '0046_scheduledmessage_unique'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='leadscheduledmessage',
+            constraint=models.UniqueConstraint(
+                fields=['lead_id', 'content'],
+                name='uniq_lead_content',
+            ),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -265,6 +265,14 @@ class LeadScheduledMessage(models.Model):
     active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["lead_id", "content"],
+                name="uniq_lead_content",
+            )
+        ]
+
     def schedule_next(self):
         self.next_run = timezone.now() + timedelta(minutes=self.interval_minutes)
         self.save(update_fields=["next_run"])

--- a/backend/webhooks/tests/test_unique_constraints.py
+++ b/backend/webhooks/tests/test_unique_constraints.py
@@ -2,7 +2,11 @@ from django.test import TestCase
 from django.db import IntegrityError
 from django.utils import timezone
 
-from webhooks.models import ScheduledMessage, FollowUpTemplate
+from webhooks.models import (
+    ScheduledMessage,
+    FollowUpTemplate,
+    LeadScheduledMessage,
+)
 
 
 class ScheduledMessageUniqueConstraintTests(TestCase):
@@ -17,5 +21,20 @@ class ScheduledMessageUniqueConstraintTests(TestCase):
             ScheduledMessage.objects.create(
                 lead_id='l1',
                 template=tpl,
+                next_run=timezone.now(),
+            )
+
+    def test_lead_scheduled_unique_constraint(self):
+        LeadScheduledMessage.objects.create(
+            lead_id='l1',
+            content='hello',
+            interval_minutes=60,
+            next_run=timezone.now(),
+        )
+        with self.assertRaises(IntegrityError):
+            LeadScheduledMessage.objects.create(
+                lead_id='l1',
+                content='hello',
+                interval_minutes=60,
                 next_run=timezone.now(),
             )


### PR DESCRIPTION
## Summary
- enforce unique `lead_id`+`content` for `LeadScheduledMessage`
- add migration for the new constraint
- test IntegrityError when duplicates are inserted

## Testing
- `python manage.py test webhooks.tests.test_unique_constraints -v 2` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68754153694c832da08cae07bb3150cd