### PR TITLE
Fix LeadPendingTask migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ google-credentials.json
 *.key
 *.pem
 backend/logs/
+backend/venv/
 "backend/service_account.json"

--- a/backend/webhooks/migrations/0048_leadpendingtask_text.py
+++ b/backend/webhooks/migrations/0048_leadpendingtask_text.py
@@ -1,4 +1,10 @@
 from django.db import migrations, models
+from django.db.models import F
+
+
+def set_initial_text(apps, schema_editor):
+    LeadPendingTask = apps.get_model("webhooks", "LeadPendingTask")
+    LeadPendingTask.objects.all().update(text=F("task_id"))
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -12,6 +18,7 @@ class Migration(migrations.Migration):
             field=models.TextField(default=""),
             preserve_default=False,
         ),
+        migrations.RunPython(set_initial_text, reverse_code=migrations.RunPython.noop),
         migrations.AddConstraint(
             model_name="leadpendingtask",
             constraint=models.UniqueConstraint(


### PR DESCRIPTION
## Summary
- populate `LeadPendingTask.text` before enforcing uniqueness
- ignore local virtual env in git

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68758e3792b0832d9b6bf12bb796033b