### PR TITLE
Implement lead locking and worker concurrency

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: celery -A config worker --loglevel=info
+    command: celery -A config worker --loglevel=info --concurrency=4
     restart: unless-stopped
     environment:
       CELERY_BROKER_URL: "redis://redis:6379/0"


### PR DESCRIPTION
## Summary
- prevent concurrent follow-up tasks per `lead_id` using cache locks
- serialise scheduled message execution with the same lock
- limit Celery worker concurrency in docker-compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6875928e177c832dae1d6d7831dd5d80