### PR TITLE
Add Grafana service

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,15 @@ python backend/manage.py cleanup_celery_logs --days 30
 This command is executed automatically every day via Celery beat using the
 `cleanup-celery-logs` schedule.
 
+## Grafana dashboards
+
+The stack now includes a Grafana service for visualizing logs from Loki. Start
+the services with Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+Open <http://localhost:3002> in your browser to access the Grafana UI. Configure
+Loki as a data source and set the URL to `http://loki:3100`.
+

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -258,7 +258,7 @@ GOOGLE_SERVICE_ACCOUNT_FILE = BASE_DIR / "service_account.json"
 
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:3000',
-    'http://localhost:3001',
+    'http://localhost:3002',
     'http://46.62.139.177:3000',
 ]
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -120,6 +120,14 @@ services:
     depends_on:
       - loki
 
+  grafana:
+    image: grafana/grafana:latest
+    restart: unless-stopped
+    ports:
+      - "3002:3000"
+    depends_on:
+      - loki
+
 volumes:
   postgres_data:
   redis_data:


### PR DESCRIPTION
## Summary
- include Grafana container
- document how to start and access Grafana
- use port 3002 instead of 3001

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r backend/requirements.txt` *(fails: could not fetch from PyPI)*


------
https://chatgpt.com/codex/tasks/task_e_6877a8844280832dab89552cd14c4c0e