### PR TITLE
Add note about RQ job deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ volumes:
 After updating the compose file, run `docker compose up -d` again to apply the
 changes. Scheduled tasks and other Redis data will persist between restarts.
 
+If you need additional safeguards against duplicate jobs, assign deterministic
+`job_id` values when enqueuing RQ tasks. For example, hash the `lead_id` and
+message text and pass that value as the `job_id`. Attempting to enqueue the same
+task again with the identical `job_id` simply reuses the existing job and no new
+task is created.
+
 ## Webhook event processing
 
 When events are fetched from Yelp after a lead is created, the backend ignores


### PR DESCRIPTION
## Summary
- document how to avoid duplicate RQ tasks using deterministic `job_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6877f1e3760c832d921730586ca672c1