### PR TITLE
Remove Loki setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,4 @@ python backend/manage.py cleanup_celery_logs --days 30
 This command is executed automatically every day via the RQ scheduler using the
 `cleanup-celery-logs` schedule.
 
-## Grafana dashboards
-
-The stack now includes a Grafana service for visualizing logs from Loki. Start
-the services with Docker Compose:
-
-```bash
-docker compose up -d
-```
-
-Open <http://localhost:3002> in your browser to access the Grafana UI. Configure
-Loki as a data source and set the URL to `http://loki:3100`.
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,10 +24,6 @@ services:
       - .:/app
     ports:
       - "8000:8000"
-    logging:
-      driver: loki
-      options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
@@ -66,10 +62,6 @@ services:
       POSTGRES_DB: "postgres"
     volumes:
       - .:/app
-    logging:
-      driver: loki
-      options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
@@ -89,38 +81,10 @@ services:
       POSTGRES_DB: "postgres"
     volumes:
       - .:/app
-    logging:
-      driver: loki
-      options:
-        loki-url: "http://loki:3100/loki/api/v1/push"
     depends_on:
       - redis
       - db
 
-  loki:
-    image: grafana/loki:2.9.5
-    restart: unless-stopped
-    ports:
-      - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
-
-  promtail:
-    image: grafana/promtail:2.9.5
-    restart: unless-stopped
-    volumes:
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: -config.file=/etc/promtail/docker-config.yaml
-    depends_on:
-      - loki
-
-  grafana:
-    image: grafana/grafana:latest
-    restart: unless-stopped
-    ports:
-      - "3002:3000"
-    depends_on:
-      - loki
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- remove Grafana and Loki services from docker-compose
- revert to default Docker log driver
- update README to remove Grafana instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6877fc3b9804832d848b950895838903