### PR TITLE
Integrate RQ Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,4 +128,13 @@ python backend/manage.py cleanup_celery_logs --days 30
 This command is executed automatically every day via the RQ scheduler using the
 `cleanup-celery-logs` schedule.
 
+## RQ Dashboard
+
+The compose file includes a `rqdash` service running [RQ Dashboard](https://github.com/rq/rq-dashboard).
+Start it and visit <http://localhost:9181> to monitor queued jobs:
+
+```bash
+docker compose up -d rqdash
+```
+
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -85,6 +85,19 @@ services:
       - redis
       - db
 
+  rqdash:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: rq-dashboard -H 0.0.0.0 -p 9181
+    restart: unless-stopped
+    environment:
+      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/1
+    ports:
+      - "9181:9181"
+    depends_on:
+      - redis
+
 
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ django-cors-headers>=4,<5
 requests
 django-rq
 rq-scheduler
+rq-dashboard
 uvicorn[standard]>=0.23.0
 gspread
 google-auth


### PR DESCRIPTION
## Summary
- add rq-dashboard dependency
- run rqdash service in docker compose
- document RQ Dashboard usage

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<6.0,>=5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68780e2ecadc832db9f979b998b1fd09