### PR TITLE
Add scheduler dashboard service

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,14 @@ Start it and visit <http://localhost:9181> to monitor queued jobs:
 docker compose up -d rqdash
 ```
 
+## RQ Scheduler Dashboard
+
+To inspect jobs scheduled with `rq-scheduler`, the compose file also includes a
+`scheduler-dashboard` service. Start it and open
+<http://localhost:9182> to view scheduled tasks:
+
+```bash
+docker compose up -d scheduler-dashboard
+```
+
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -98,6 +98,15 @@ services:
     depends_on:
       - redis
 
+  scheduler-dashboard:
+    image: ghcr.io/ducu/rq-scheduler-dashboard:latest
+    command: rq-scheduler-dashboard --redis-url redis://redis:6379/1
+    restart: unless-stopped
+    ports:
+      - "9182:9182"
+    depends_on:
+      - redis
+
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- add `scheduler-dashboard` service for rq-scheduler-dashboard
- document how to run the dashboard for scheduled jobs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68781233560c832db61b6caf4233d324