### PR TITLE
Embed scheduler dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ docker compose up -d rqdash
 
 ## RQ Scheduler Dashboard
 
-To inspect jobs scheduled with `rq-scheduler`, the compose file also includes a
-`scheduler-dashboard` service. Start it and open
+To inspect jobs scheduled with `rq-scheduler`, the compose file includes a
+`scheduler-dashboard` service built from the same Docker image as the other
+backend components. Start it and open
 <http://localhost:9182> to view scheduled tasks:
 
 ```bash

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -99,7 +99,9 @@ services:
       - redis
 
   scheduler-dashboard:
-    image: ghcr.io/ducu/rq-scheduler-dashboard:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     command: rq-scheduler-dashboard --redis-url redis://redis:6379/1
     restart: unless-stopped
     ports:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ requests
 django-rq
 rq-scheduler
 rq-dashboard
+rq-scheduler-dashboard
 uvicorn[standard]>=0.23.0
 gspread
 google-auth


### PR DESCRIPTION
## Summary
- include rq-scheduler-dashboard package in backend image
- build scheduler-dashboard service from local Dockerfile
- clarify README instructions for scheduler dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python backend/manage.py check --settings=config.settings` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687819cebcdc832db67fcd2dd1187284