### PR TITLE
Add pinned rq dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
+rq==1.13.1
+rq-scheduler-dashboard==0.4.6
 Django>=5.0,<6.0
 djangorestframework
 gunicorn


### PR DESCRIPTION
## Summary
- pin `rq` and `rq-scheduler-dashboard` at the top of backend requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687826c6a05c832d80eacbd4254383e8