### PR TITLE
Fix duplicate rq requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,8 +9,6 @@ requests
 django-rq
 rq-scheduler
 rq-dashboard
-rq<2.0.0
-rq-scheduler-dashboard
 uvicorn[standard]>=0.23.0
 gspread
 google-auth


### PR DESCRIPTION
## Summary
- clean up duplicate rq and dashboard requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r backend/requirements.txt` *(fails: could not connect to pypi)*

------
https://chatgpt.com/codex/tasks/task_e_687829316b7c832da861d208504e461b