### PR TITLE
Add RQ dashboard queue config

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -89,10 +89,13 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: rq-dashboard -H 0.0.0.0 -p 9181
+    command: >
+      rq-dashboard
+      --redis-url redis://redis:6379/1
+      --host 0.0.0.0
+      --port 9181
+      --queues default,high,emails,scheduled_jobs
     restart: unless-stopped
-    environment:
-      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/1
     ports:
       - "9181:9181"
     depends_on:
@@ -102,7 +105,9 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: rq-scheduler-dashboard --redis-url redis://redis:6379/1
+    command: >
+      rq-scheduler-dashboard
+      --redis-url redis://redis:6379/1
     restart: unless-stopped
     ports:
       - "9182:9182"


### PR DESCRIPTION
## Summary
- update `rqdash` service in compose to pass explicit redis URL, port, host and queues
- format `scheduler-dashboard` command with multiline style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687833edfc98832d9cc93bf70b32d1af