### PR TITLE
Fix rqdash redis URL

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     command: rq-dashboard -b 0.0.0.0 -p 9181
     restart: unless-stopped
     environment:
-      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/1
+      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/0
       RQ_DASHBOARD_QUEUES: default,high,emails,scheduled_jobs
     ports:
       - "9181:9181"


### PR DESCRIPTION
## Summary
- point rqdash at Redis DB 0 instead of DB 1

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68783cb8d394832d80fb991a1aa66cd3