### PR TITLE
Patch scheduler dashboard startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ docker compose up -d rqdash
 
 To inspect jobs scheduled with `rq-scheduler`, the compose file includes a
 `scheduler-dashboard` service built from the same Docker image as the other
-backend components. Start it and open
+backend components. The service automatically patches
+`rq_scheduler_dashboard` at runtime so it works with newer Flask versions.
+Start it and open
 <http://localhost:9182> to view scheduled tasks:
 
 ```bash

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -103,9 +103,13 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: >
-      rq-scheduler-dashboard
-      --redis-url redis://redis:6379/1
+    # Patch rq_scheduler_dashboard to avoid deprecated hook
+    command: >-
+      sh -c "
+        sed -i 's/before_app_first_request/before_app_request/' \
+          /usr/local/lib/python3.12/site-packages/rq_scheduler_dashboard/web.py &&
+        rq-scheduler-dashboard --redis-url redis://redis:6379/1
+      "
     restart: unless-stopped
     ports:
       - "9182:9182"


### PR DESCRIPTION
## Summary
- patch `rq_scheduler_dashboard` at runtime to work with Flask
- document scheduler dashboard patch in README

## Testing
- `python backend/manage.py test` *(fails: No module named 'django')*
- `python -m pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement rq==1.13.1)*

------
https://chatgpt.com/codex/tasks/task_e_68783fdfef3c832db585043f93c76089