### PR TITLE
Add Redis Commander service

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,4 +150,13 @@ Start it and open
 docker compose up -d scheduler-dashboard
 ```
 
+## Redis Commander
+
+To inspect the Redis database through a web interface, the compose file includes
+a `redis-commander` service. Start it and visit <http://localhost:8081>:
+
+```bash
+docker compose up -d redis-commander
+```
+
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -116,6 +116,16 @@ services:
     depends_on:
       - redis
 
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    environment:
+      REDIS_HOSTS: local:redis:6379
+    depends_on:
+      - redis
+
 volumes:
   postgres_data:
   redis_data:


### PR DESCRIPTION
## Summary
- add redis-commander service to docker-compose
- document redis-commander in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687851537b4c832d8a9759b7b5e3df4c