### PR TITLE
Fix RQ job cancellation

### DIFF
--- a/backend/webhooks/task_views.py
+++ b/backend/webhooks/task_views.py
@@ -75,7 +75,9 @@ class TaskRevokeView(APIView):
         queue = django_rq.get_queue("default")
         scheduler = django_rq.get_scheduler("default")
         try:
-            queue.cancel_job(task_id)
+            job = queue.fetch_job(task_id)
+            if job:
+                job.cancel()
             scheduler.cancel(task_id)
         except Exception as exc:
             logger.error(f"[TASK] Error revoking {task_id}: {exc}")

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -335,7 +335,9 @@ class WebhookView(APIView):
         scheduler = django_rq.get_scheduler("default")
         for p in pending:
             try:
-                queue.cancel_job(p.task_id)
+                job = queue.fetch_job(p.task_id)
+                if job:
+                    job.cancel()
                 scheduler.cancel(p.task_id)
             except Exception as exc:
                 logger.error(f"[AUTO-RESPONSE] Error revoking task {p.task_id}: {exc}")


### PR DESCRIPTION
## Summary
- fix task cancel view to fetch and cancel the job
- apply same logic for auto-response job cancellation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878cfc4f2a4832db32eb4575966ad85