### PR TITLE
Switch dashboards to Redis DB 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This command is executed automatically every day via the RQ scheduler using the
 ## RQ Dashboard
 
 The compose file includes a `rqdash` service running [RQ Dashboard](https://github.com/rq/rq-dashboard).
+RQ uses Redis database 1, so `rqdash` connects to `redis://redis:6379/1`.
 Start it and visit <http://localhost:9181> to monitor queued jobs:
 
 ```bash
@@ -153,7 +154,8 @@ docker compose up -d scheduler-dashboard
 ## Redis Commander
 
 To inspect the Redis database through a web interface, the compose file includes
-a `redis-commander` service. Start it and visit <http://localhost:8081>:
+a `redis-commander` service. It is configured to use database 1 so it shows RQ's
+queues. Start it and visit <http://localhost:8081>:
 
 ```bash
 docker compose up -d redis-commander

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     command: rq-dashboard -b 0.0.0.0 -p 9181
     restart: unless-stopped
     environment:
-      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/0
+      RQ_DASHBOARD_REDIS_URL: redis://redis:6379/1
       RQ_DASHBOARD_QUEUES: default,high,emails,scheduled_jobs
     ports:
       - "9181:9181"
@@ -122,7 +122,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      REDIS_HOSTS: local:redis:6379
+      REDIS_HOSTS: local:redis:6379:1
     depends_on:
       - redis
 


### PR DESCRIPTION
## Summary
- connect RQ Dashboard and Redis Commander to Redis database 1
- document that these services use DB 1

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687993192a24832da01ba8b7d0eeba3f