### PR TITLE
Fix HTTPError handling in send_follow_up

### DIFF
--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -7,6 +7,7 @@ import functools
 
 import redis
 import requests
+from requests.exceptions import HTTPError
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone


### PR DESCRIPTION
## Summary
- handle HTTP errors properly by importing HTTPError in `send_follow_up`

## Testing
- `python3 manage.py test webhooks.tests.test_webhook_events -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a1e7b49ac832db040d1d1ba52f3aa