### PR TITLE
Handle blank follow-up messages

### DIFF
--- a/backend/webhooks/tasks.py
+++ b/backend/webhooks/tasks.py
@@ -123,6 +123,10 @@ def send_follow_up(lead_id: str, text: str, business_id: str | None = None):
         logger.info("[FOLLOW-UP] Duplicate follow-up for lead=%s; skipping", lead_id)
         return
 
+    if not text.strip():
+        logger.warning("[FOLLOW-UP] Empty follow-up text for lead=%s; skipping", lead_id)
+        return
+
     lock_id = f"lead-lock:{lead_id}"
     try:
         with _get_lock(lock_id, timeout=LOCK_TIMEOUT, blocking_timeout=5):

--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -10,7 +10,9 @@ from webhooks.models import (
     YelpBusiness,
     AutoResponseSettings,
     LeadDetail,
+    LeadEvent,
 )
+from webhooks.tasks import send_follow_up
 
 
 class WebhookEventProcessingTests(TestCase):
@@ -284,4 +286,12 @@ class AutoResponseDisabledTests(TestCase):
 
         self.assertTrue(LeadDetail.objects.filter(lead_id=self.lead_id).exists())
         mock_follow_up.assert_not_called()
+
+
+class SendFollowUpTests(TestCase):
+    def test_empty_message_skipped(self):
+        with self.assertLogs('webhooks.tasks', level='WARNING') as cm:
+            send_follow_up.__wrapped__('lead-x', '   ')
+        self.assertEqual(LeadEvent.objects.count(), 0)
+        self.assertIn('Empty follow-up text', cm.output[0])
 


### PR DESCRIPTION
## Summary
- skip sending follow-up when text is blank
- add regression test for empty follow-ups

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a319f22a8832db0e440ccbfd79ae9