### PR TITLE
Fix old consumer event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ task is created.
 ## Webhook event processing
 
 When events are fetched from Yelp after a lead is created, the backend ignores
-consumer messages that occurred **before** the lead was processed **unless** the
-message contains a phone number. This prevents the initial lead message from
-cancelling pending auto-response tasks, while still capturing phone numbers that
-might appear in that first message. Events created after
-`ProcessedLead.processed_at` always trigger phone number logic.
+consumer messages that occurred **before** the lead was processed. Only events
+created after `ProcessedLead.processed_at` are considered for automatic
+responses. The backend triggers phone number logic only when a new consumer
+message contains a phone number.
 
 Phone numbers found in a lead's `additional_info` field also trigger the "real
 phone provided" flow when the lead is first processed.


### PR DESCRIPTION
## Summary
- ignore any event older than `ProcessedLead.processed_at`
- trigger `handle_phone_available` only for new consumer messages
- update documentation for new webhook behavior
- adjust tests for old events and add regression check for business messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687a4c221a64832d871d9bbb14aa64e4