### PR TITLE
Fix API URL reference

### DIFF
--- a/frontend/src/EventsPage/EventsPage.tsx
+++ b/frontend/src/EventsPage/EventsPage.tsx
@@ -29,7 +29,7 @@ import EventNoteIcon from '@mui/icons-material/EventNote';
 
 const POLL_INTERVAL = 30000;
 
-const API_BASE = process.env.VITE_API_BASE_URL || 'http://46.62.139.177:8000';
+const API_BASE = import.meta.env.VITE_API_URL || 'http://46.62.139.177:8000';
 
 interface PaginatedResponse<T> {
   count: number;


### PR DESCRIPTION
## Summary
- update `EventsPage.tsx` to use `import.meta.env.VITE_API_URL`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b20955118832da1215e630d6a39b8