### PR TITLE
Fix API base URL env access

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,8 +64,8 @@ const theme = createTheme({
 });
 
 // Base URL for the API
-axios.defaults.baseURL = process.env.VITE_API_BASE_URL
-  ? `${process.env.VITE_API_BASE_URL}/api`
+axios.defaults.baseURL = import.meta.env.VITE_API_BASE_URL
+  ? `${import.meta.env.VITE_API_BASE_URL}/api`
   : 'http://46.62.139.177:8000/api';
 
 


### PR DESCRIPTION
## Summary
- fix environment variable access in App.tsx

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b23015a6c832db7c768cd359200e2