### PR TITLE
Add logout button in header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,6 +59,11 @@ const App: FC = () => {
     localStorage.getItem('isAuthenticated') === 'true'
   );
 
+  const handleLogout = () => {
+    localStorage.removeItem('isAuthenticated');
+    setAuthenticated(false);
+  };
+
   if (!authenticated) {
     return (
       <ThemeProvider theme={theme}>
@@ -81,7 +86,7 @@ const App: FC = () => {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Router>
-        <TopMenu />
+        <TopMenu onLogout={handleLogout} />
         <Box component="main" sx={{ p: 3 }}>
           <Routes>
               <Route path="/" element={<Home />} />

--- a/frontend/src/TopMenu.tsx
+++ b/frontend/src/TopMenu.tsx
@@ -10,6 +10,7 @@ import ChecklistIcon from '@mui/icons-material/Checklist';
 import DescriptionIcon from '@mui/icons-material/Description';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LoginIcon from '@mui/icons-material/Login';
+import LogoutIcon from '@mui/icons-material/Logout';
 
 const menuItems = [
   { text: 'Home', icon: <HomeIcon />, href: '/' },
@@ -23,13 +24,17 @@ const menuItems = [
   { text: 'Authorize with Yelp', icon: <LoginIcon />, href: '/auth' },
 ];
 
-const TopMenu: React.FC = () => {
+interface Props {
+  onLogout: () => void;
+}
+
+const TopMenu: React.FC<Props> = ({ onLogout }) => {
   const location = useLocation();
 
   return (
     <AppBar position="static" color="default" elevation={0}>
       <Toolbar>
-        <Box sx={{ display: 'flex', gap: 2 }}>
+        <Box sx={{ display: 'flex', gap: 2, flexGrow: 1 }}>
           {menuItems.map((item) => (
             <Button
               key={item.text}
@@ -44,6 +49,13 @@ const TopMenu: React.FC = () => {
             </Button>
           ))}
         </Box>
+        <Button
+          startIcon={<LogoutIcon />}
+          onClick={onLogout}
+          sx={{ ml: 'auto', color: 'secondary.main' }}
+        >
+          Logout
+        </Button>
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
## Summary
- add `onLogout` callback to `TopMenu`
- render Logout button at the end of the header with a secondary color
- store a handler in `App` to clear authentication state and pass it to `TopMenu`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687dd6c058f8832db5197b87f9f5782d