### PR TITLE
Remove obsolete Templates link

### DIFF
--- a/frontend/src/TopMenu.tsx
+++ b/frontend/src/TopMenu.tsx
@@ -17,7 +17,6 @@ const menuItems = [
   { text: 'Tokens&Business', icon: <VpnKeyIcon />, href: '/tokens' },
   { text: 'Subscriptions', icon: <SubscriptionsIcon />, href: '/subscriptions' },
   { text: 'Tasks', icon: <ChecklistIcon />, href: '/tasks' },
-  { text: 'Templates', icon: <DescriptionIcon />, href: '/templates' },
   { text: 'Auto-response Settings', icon: <SettingsIcon />, href: '/settings' },
   { text: 'Authorize with Yelp', icon: <LoginIcon />, href: '/auth' },
 ];


### PR DESCRIPTION
## Summary
- remove the Templates menu item from the header navigation

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de2f57f88832d9b137d8ecb62d768