### PR TITLE
Simplify settings page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import EventDetail from "./Events/EventDetail";
 import EventsPage from "./EventsPage/EventsPage";
 import Home from "./Home";
 import YelpCallback from "./YelpCallback";
-import AutoResponseSettings from "./AutoResponseSettings";
+import ChooseBusiness from "./ChooseBusiness";
 import YelpAuth from "./YelpAuth";
 import ClientDetails from "./ClientDetails/ClientDetails";
 import TokenStatus from "./TokenStatus";
@@ -93,7 +93,7 @@ const App: FC = () => {
               <Route path="/leads/:id" element={<ClientDetails />} />
               <Route path="/auth" element={<YelpAuth />} />
               <Route path="/callback" element={<YelpCallback />} />
-              <Route path="/settings" element={<AutoResponseSettings />} />
+              <Route path="/settings" element={<ChooseBusiness />} />
               <Route path="/tokens" element={<TokenStatus />} />
               <Route path="/subscriptions" element={<Subscriptions />} />
               <Route path="/tasks" element={<TaskLogs />} />

--- a/frontend/src/ChooseBusiness.tsx
+++ b/frontend/src/ChooseBusiness.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useState, useEffect } from 'react';
+import axios from 'axios';
+import { Container, Select, MenuItem, Box } from '@mui/material';
+
+interface Business {
+  business_id: string;
+  name: string;
+  location?: string;
+  time_zone?: string;
+}
+
+const ChooseBusiness: FC = () => {
+  const [businesses, setBusinesses] = useState<Business[]>([]);
+  const [selectedBusiness, setSelectedBusiness] = useState('');
+
+  useEffect(() => {
+    axios.get<Business[]>('/businesses/')
+      .then(res => setBusinesses(res.data))
+      .catch(() => setBusinesses([]));
+  }, []);
+
+  return (
+    <Container maxWidth={false} sx={{ mt: 4, mb: 4, maxWidth: 1000, mx: 'auto' }}>
+      <Box sx={{ mb: 2 }}>
+        <Select
+          value={selectedBusiness}
+          onChange={e => setSelectedBusiness(e.target.value as string)}
+          displayEmpty
+          size="small"
+          sx={{ mt: 2 }}
+        >
+          <MenuItem value="" disabled>
+            <em>Choose business</em>
+          </MenuItem>
+          {businesses.map(b => (
+            <MenuItem key={b.business_id} value={b.business_id}>
+              {b.name}
+              {b.location ? ` (${b.location})` : ''}
+              {b.time_zone ? ` - ${b.time_zone}` : ''}
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
+    </Container>
+  );
+};
+
+export default ChooseBusiness;


### PR DESCRIPTION
## Summary
- add `ChooseBusiness` component with only the business selector
- route `/settings` to the new component

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687de6578c08832d9ec72b9d3e0d69ad