### PR TITLE
Fix settings load error

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -303,7 +303,6 @@ const AutoResponseSettings: FC = () => {
             export_to_sheets: d.export_to_sheets,
             follow_up_templates: initialSettings.current?.follow_up_templates || [],
           };
-          setAppliedTemplateId(null);
           setLoading(false);
         })
         .catch(err => {


### PR DESCRIPTION
## Summary
- fix missing `setAppliedTemplateId` call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687e0888b15c832db9494e1a79bd203e