### PR TITLE
Hide Auto-response content until business selected

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -696,6 +696,33 @@ const AutoResponseSettings: FC = () => {
     setError('');
   };
 
+  if (!selectedBusiness) {
+    return (
+      <Container maxWidth={false} sx={{ mt:4, mb:4, maxWidth: 1000, mx: 'auto' }}>
+        <Box sx={{ mb: 2 }}>
+          <Select
+            value={selectedBusiness}
+            onChange={e => setSelectedBusiness(e.target.value as string)}
+            displayEmpty
+            size="small"
+            sx={{ mt: 2 }}
+          >
+            <MenuItem value="" disabled>
+              <em>Choose business</em>
+            </MenuItem>
+            {businesses.map(b => (
+              <MenuItem key={b.business_id} value={b.business_id}>
+                {b.name}
+                {b.location ? ` (${b.location})` : ''}
+                {b.time_zone ? ` - ${b.time_zone}` : ''}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      </Container>
+    );
+  }
+
   return (
     <Container maxWidth={false} sx={{ mt:4, mb:4, maxWidth: 1000, mx: 'auto' }}>
       <Box sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- hide Auto-response form while no business is selected

## Testing
- `npm test --silent -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e0ad61140832db01f7f8af8f4b3c6