### PR TITLE
Update rq requirement spec

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-rq==1.13.0
+rq>=1.13.0,<2.0.0
 rq-scheduler-dashboard==0.4.6
 Django>=5.0,<6.0
 djangorestframework


### PR DESCRIPTION
## Summary
- loosen rq pinning so any 1.x release is allowed

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e34c03fc4832db1f8ea640424807c