### PR TITLE
Adjust scheduler dashboard requirement

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 rq>=1.13.0,<2.0.0
-rq-scheduler-dashboard==0.4.6
+rq-scheduler-dashboard>=0.0.2,<1.0.0
 Django>=5.0,<6.0
 djangorestframework
 gunicorn


### PR DESCRIPTION
## Summary
- allow flexible version for `rq-scheduler-dashboard`

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find rq<2.0.0 due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687e36065d1c832db696938fb58aa4e2