### PR TITLE
Handle phone opt-in when detecting new leads

### DIFF
--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -232,6 +232,34 @@ class LeadIdVerificationTests(TestCase):
     @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
     @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
     @patch.object(WebhookView, "handle_new_lead")
+    def test_mark_new_lead_with_phone_opt_in(
+        self,
+        mock_new_lead,
+        mock_lead_token,
+        mock_business_token,
+        mock_get
+    ):
+        events_resp = type(
+            "E",
+            (),
+            {
+                "status_code": 200,
+                "json": lambda self: {
+                    "events": [
+                        {"id": "e0", "user_type": "CONSUMER"},
+                        {"id": "e1", "event_type": "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT"},
+                    ]
+                },
+            },
+        )()
+        mock_get.return_value = events_resp
+        self._post()
+        mock_new_lead.assert_called_once_with(self.lead_id)
+
+    @patch("webhooks.webhook_views.requests.get")
+    @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
+    @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
+    @patch.object(WebhookView, "handle_new_lead")
     def test_existing_lead_not_marked(
         self,
         mock_new_lead,

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -104,7 +104,13 @@ class WebhookView(APIView):
             return {"new_lead": False}
 
         events = resp.json().get("events", [])
-        is_new = len(events) == 1 and events[0].get("user_type") == "CONSUMER"
+        is_new = (
+            len(events) == 1 and events[0].get("user_type") == "CONSUMER"
+        ) or (
+            len(events) == 2
+            and events[0].get("user_type") == "CONSUMER"
+            and events[1].get("event_type") == "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT"
+        )
         return {"new_lead": is_new}
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
## Summary
- update `_is_new_lead` logic to also accept a phone opt-in event as part of the initial events
- test new case where two events exist: the consumer message and a phone opt‑in event

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ea7ff2230832da931e30645f8c27e