### PR TITLE
Sort follow-up templates chronologically

### DIFF
--- a/frontend/src/AutoResponseSettings.tsx
+++ b/frontend/src/AutoResponseSettings.tsx
@@ -1220,7 +1220,10 @@ const AutoResponseSettings: FC = () => {
                     </Paper>
                   ) : (
                     <Stack spacing={2}>
-                      {templates.map((t, index) => (
+                      {templates
+                        .slice()
+                        .sort((a, b) => a.delay - b.delay)
+                        .map((t, index) => (
                         <Card 
                           key={t.id}
                           elevation={1}

--- a/frontend/src/SettingsTemplates.tsx
+++ b/frontend/src/SettingsTemplates.tsx
@@ -312,7 +312,10 @@ const SettingsTemplates: React.FC = () => {
 
             <Typography variant="h6">Additional Follow-up Templates</Typography>
             <List dense>
-              {(data.follow_up_templates || []).map((t, idx) => (
+              {(data.follow_up_templates || [])
+                .slice()
+                .sort((a, b) => a.delay - b.delay)
+                .map((t, idx) => (
                 <ListItem key={idx} secondaryAction={
                   <IconButton edge="end" onClick={() => handleDeleteFollowTemplate(idx)}>
                     <DeleteIcon />


### PR DESCRIPTION
## Summary
- sort follow-up templates by delay in AutoResponseSettings
- sort follow-up templates by delay in SettingsTemplates

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*
- `pytest backend/webhooks/tests/test_webhook_events.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f72f6f5dc832da627067fa50f1e7e