### PR TITLE
Fix missing slash when fetching lead events

### DIFF
--- a/frontend/src/EventsPage/NewLeads.tsx
+++ b/frontend/src/EventsPage/NewLeads.tsx
@@ -22,6 +22,9 @@ import InfoIcon from '@mui/icons-material/Info';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import EventIcon from '@mui/icons-material/Event';
 
+// Base URL for API requests
+const API_BASE = import.meta.env.VITE_API_URL || 'http://46.62.139.177:8000';
+
 interface Props {
   leads: ProcessedLead[];
   leadDetails: Record<string, Partial<LeadDetailType>>;
@@ -67,7 +70,7 @@ const NewLeads: FC<Props> = ({
       for (const lid of toFetch) {
         try {
           const { data } = await axios.get<LeadEvent>(
-            `/lead-events/${encodeURIComponent(lid)}/latest/`
+            `${API_BASE}/api/lead-events/${encodeURIComponent(lid)}/latest/`
           );
           if (data.event_id) {
             setFetchedEvents(prev => ({ ...prev, [lid]: String(data.event_id) }));


### PR DESCRIPTION
## Summary
- ensure correct API base is used when retrieving latest lead events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f8f380168832d80171ae327888638