### PR TITLE
Improve logging for lead-event fetch

### DIFF
--- a/backend/webhooks/lead_views.py
+++ b/backend/webhooks/lead_views.py
@@ -197,12 +197,18 @@ class LeadLastEventAPIView(APIView):
     """Return latest LeadEvent by lead_id"""
 
     def get(self, request, lead_id: str):
+        logger.info(
+            f"[LEAD LAST EVENT] Fetching latest event for lead_id={lead_id} path={request.path}"
+        )
         obj = (
             LeadEvent.objects.filter(lead_id=lead_id)
             .order_by("-time_created")
             .first()
         )
         if not obj:
+            logger.info(
+                f"[LEAD LAST EVENT] LeadEvent with lead_id={lead_id} not found"
+            )
             raise NotFound(detail=f"LeadEvent з lead_id={lead_id} не знайдено")
         serializer = LeadEventSerializer(obj)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- log path and lead_id when retrieving the latest lead event
- log when no lead event is found

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f961152d0832da9b5100543536f1a