### PR TITLE
Fix missing token error in WebhookView

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -305,8 +305,23 @@ class WebhookView(APIView):
 
         biz_id = payload["data"].get("id")
         for lid in lead_ids:
-            token = get_valid_business_token(biz_id)
-            logger.info(f"[WEBHOOK] Using business token for lead={lid}: {token}")
+            try:
+                token = get_valid_business_token(biz_id)
+                logger.info(
+                    f"[WEBHOOK] Using business token for lead={lid}: {token}"
+                )
+            except ValueError:
+                logger.error(
+                    f"[WEBHOOK] Missing Yelp token for business={biz_id}; "
+                    f"skipping lead={lid}"
+                )
+                continue
+            except Exception:
+                logger.exception(
+                    f"[WEBHOOK] Error obtaining token for business={biz_id} "
+                    f"lead={lid}"
+                )
+                continue
             url = f"https://api.yelp.com/v3/leads/{lid}/events"
             params = {"limit": 20}
             resp = requests.get(


### PR DESCRIPTION
## Summary
- handle missing Yelp token when fetching lead events
- log token retrieval failures so webhook processing continues

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687fd1f801dc832dbccc6d0f9b0b485c