### PR TITLE
Fix missing utils reference

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -699,7 +699,7 @@ class WebhookView(APIView):
             days_setting = (
                 auto_settings.greeting_open_days if phone_available else None
             )
-            allowed_days = utils._parse_days(days_setting)
+            allowed_days = _parse_days(days_setting)
             open_dt = local_now.replace(
                 hour=auto_settings.greeting_open_from.hour,
                 minute=auto_settings.greeting_open_from.minute,


### PR DESCRIPTION
## Summary
- fix NameError in webhook auto-response

## Testing
- `python3 manage.py test webhooks.tests.test_webhook_events.TestCase.test_initial_event_does_not_cancel_tasks` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687fe8c5ae3c832d80ac480024f3b19f