### PR TITLE
Fix tests package structure

### DIFF
--- a/backend/webhooks/tests.py
+++ b/backend/webhooks/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
## Summary
- drop placeholder `tests.py`
- set up package for `webhooks.tests`

## Testing
- `python manage.py test webhooks.tests.test_webhook_events.BusinessTokenErrorTests -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ff4df859c832d840d79e0bce950eb