### PR TITLE
Remove processed_at filter

### DIFF
--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -65,7 +65,7 @@ class WebhookEventProcessingTests(TestCase):
             }
         ]}})()
         self._post()
-        mock_cancel.assert_not_called()
+        mock_cancel.assert_called_once()
 
     @patch("webhooks.webhook_views.requests.get")
     @patch.object(WebhookView, "_cancel_no_phone_tasks")
@@ -136,7 +136,7 @@ class WebhookEventProcessingTests(TestCase):
             },
         )()
         self._post()
-        mock_phone_available.assert_not_called()
+        mock_phone_available.assert_called_once()
         mock_cancel.assert_not_called()
 
     @patch("webhooks.webhook_views.requests.get")

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -378,17 +378,10 @@ class WebhookView(APIView):
                     .values_list("processed_at", flat=True)
                     .first()
                 )
-                event_dt = parse_datetime(defaults.get("time_created"))
                 text = defaults.get("text", "")
                 phone = _extract_phone(text)
                 has_phone = bool(phone)
                 is_new = created
-                if processed_at and event_dt:
-                    is_new = is_new and event_dt > processed_at
-
-                if not is_new:
-                    logger.info("[WEBHOOK] Ignoring old event")
-                    continue
 
                 if e.get("event_type") == "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT":
                     updated = LeadDetail.objects.filter(


### PR DESCRIPTION
## Summary
- remove processed_at comparison in webhook
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ff4ef23b4832da8931588d4166618