### PR TITLE
Add notification list support

### DIFF
--- a/backend/webhooks/migrations/0056_notification_unique_phone.py
+++ b/backend/webhooks/migrations/0056_notification_unique_phone.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("webhooks", "0055_notification_setting"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="notificationsetting",
+            name="phone_number",
+            field=models.CharField(max_length=64, unique=True),
+        ),
+    ]

--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -263,7 +263,7 @@ class LeadPendingTask(models.Model):
 class NotificationSetting(models.Model):
     """Phone number and template used to notify about new leads."""
 
-    phone_number = models.CharField(max_length=64)
+    phone_number = models.CharField(max_length=64, unique=True)
     message_template = models.TextField(
         help_text="Text with placeholders {business_id}, {lead_id}, {business_name}, {timestamp}"
     )

--- a/backend/webhooks/urls.py
+++ b/backend/webhooks/urls.py
@@ -8,7 +8,10 @@ from .views import (
     LeadDetailRetrieveAPIView, LeadLastEventAPIView, LeadEventRetrieveAPIView,
     FollowUpTemplateListCreateView, FollowUpTemplateDetailView,
     BusinessListView, BusinessLeadsView, BusinessEventsView,
-    SubscriptionProxyView, YelpTokenListView, NotificationSettingView,
+    SubscriptionProxyView,
+    YelpTokenListView,
+    NotificationSettingListCreateView,
+    NotificationSettingDetailView,
 )
 from .task_views import TaskLogListView, MessageTaskListView, TaskRevokeView
 from .sms_views import SendSMSAPIView
@@ -78,5 +81,6 @@ urlpatterns = [
     path('tasks/<str:task_id>/cancel/', TaskRevokeView.as_view(), name='task-revoke'),
     path('message_tasks/', MessageTaskListView.as_view(), name='message-task-list'),
     path('send-sms/', SendSMSAPIView.as_view(), name='send-sms'),
-    path('notifications/', NotificationSettingView.as_view(), name='notifications'),
+    path('notifications/', NotificationSettingListCreateView.as_view(), name='notification-list'),
+    path('notifications/<int:pk>/', NotificationSettingDetailView.as_view(), name='notification-detail'),
 ]

--- a/backend/webhooks/views.py
+++ b/backend/webhooks/views.py
@@ -28,7 +28,8 @@ from .lead_views import (
     FollowUpTemplateListCreateView,
     FollowUpTemplateDetailView,
     YelpTokenListView,
-    NotificationSettingView,
+    NotificationSettingListCreateView,
+    NotificationSettingDetailView,
 )
 from .task_views import TaskLogListView
 from .sms_views import SendSMSAPIView
@@ -62,5 +63,6 @@ __all__ = [
     "TaskLogListView",
     "SubscriptionProxyView",
     "SendSMSAPIView",
-    "NotificationSettingView",
+    "NotificationSettingListCreateView",
+    "NotificationSettingDetailView",
 ]


### PR DESCRIPTION
## Summary
- support multiple NotificationSetting rows and unique phone numbers
- expose list/create/detail API endpoints
- display all saved notifications in Notifications page
- send SMS to all saved numbers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6880cd2752fc832d89994359624d7136