### PR TITLE
Add phone variable to notifications

### DIFF
--- a/backend/webhooks/models.py
+++ b/backend/webhooks/models.py
@@ -265,7 +265,10 @@ class NotificationSetting(models.Model):
 
     phone_number = models.CharField(max_length=64, unique=True)
     message_template = models.TextField(
-        help_text="Text with placeholders {business_id}, {lead_id}, {business_name}, {timestamp}"
+        help_text=(
+            "Text with placeholders {business_id}, {lead_id}, "
+            "{business_name}, {timestamp}, {phone}"
+        )
     )
 
     def __str__(self):

--- a/backend/webhooks/signals.py
+++ b/backend/webhooks/signals.py
@@ -28,6 +28,7 @@ def notify_new_lead(sender, instance: LeadDetail, created: bool, **kwargs):
             lead_id=instance.lead_id,
             business_name=business.name if business else "",
             timestamp=timezone.now().isoformat(),
+            phone=instance.phone_number,
         )
 
         payload = {"to": setting.phone_number, "body": message}


### PR DESCRIPTION
## Summary
- allow {phone} variable in notification templates
- make placeholder chips clickable on notifications page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6880d2b92f94832dba05fdd3b2e61274