### PR TITLE
Improve phone extraction

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -38,14 +38,20 @@ logger = logging.getLogger(__name__)
 # Simple pattern to detect phone numbers like +380XXXXXXXXX or other
 # international formats with optional spaces or dashes.
 PHONE_RE = re.compile(r"\+?\d[\d\s\-\(\)]{8,}\d")
+# Simple pattern to detect ISO-like dates such as 2023-12-31
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def _extract_phone(text: str) -> str | None:
     """Return first phone number found in text, if any."""
     if not text:
         return None
-    m = PHONE_RE.search(text)
-    return m.group() if m else None
+    for m in PHONE_RE.finditer(text):
+        candidate = m.group()
+        digits = re.sub(r"\D", "", candidate)
+        if len(digits) >= 10 and not DATE_RE.fullmatch(candidate):
+            return candidate
+    return None
 
 
 def safe_update_or_create(model, defaults=None, **kwargs):


### PR DESCRIPTION
## Summary
- refine phone number detection
- skip date-like strings that look like numbers

## Testing
- `python - <<'PY'
import re, ast
from pathlib import Path
source = Path('backend/webhooks/webhook_views.py').read_text()
mod = ast.parse(source)
PHONE_RE_src = DATE_RE_src = func_src = None
for node in mod.body:
    if isinstance(node, ast.Assign):
        for t in node.targets:
            if isinstance(t, ast.Name) and t.id == 'PHONE_RE':
                PHONE_RE_src = ast.get_source_segment(source, node)
            if isinstance(t, ast.Name) and t.id == 'DATE_RE':
                DATE_RE_src = ast.get_source_segment(source, node)
    if isinstance(node, ast.FunctionDef) and node.name == '_extract_phone':
        func_src = ast.get_source_segment(source, node)
ns={'re':re}
exec(PHONE_RE_src, ns)
exec(DATE_RE_src, ns)
exec(func_src, ns)
print('Date test:', ns['_extract_phone']('2025-07-24'))
print('Phone test:', ns['_extract_phone']('Call me at +1 234-567-8901'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68811bee0788832db070215e4ef7ae8f