### PR TITLE
Handle attachment grouping as new lead

### DIFF
--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -303,6 +303,34 @@ class LeadIdVerificationTests(TestCase):
     @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
     @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
     @patch.object(WebhookView, "handle_new_lead")
+    def test_mark_new_lead_with_attachment_grouping(
+        self,
+        mock_new_lead,
+        mock_lead_token,
+        mock_business_token,
+        mock_get
+    ):
+        events_resp = type(
+            "E",
+            (),
+            {
+                "status_code": 200,
+                "json": lambda self: {
+                    "events": [
+                        {"id": "e0", "user_type": "CONSUMER"},
+                        {"id": "e1", "event_type": "ATTACHMENT_GROUPING"},
+                    ]
+                },
+            },
+        )()
+        mock_get.return_value = events_resp
+        self._post()
+        mock_new_lead.assert_called_once_with(self.lead_id)
+
+    @patch("webhooks.webhook_views.requests.get")
+    @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
+    @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
+    @patch.object(WebhookView, "handle_new_lead")
     def test_existing_lead_not_marked(
         self,
         mock_new_lead,

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -157,10 +157,16 @@ class WebhookView(APIView):
             second_event_type = events[1].get("event_type")
             if (
                 first_user_type == "CONSUMER"
-                and second_event_type == "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT"
+                and second_event_type in {
+                    "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT",
+                    "ATTACHMENT_GROUPING",
+                }
             ):
                 is_new = True
-                reason = "consumer message followed by opt-in"
+                if second_event_type == "ATTACHMENT_GROUPING":
+                    reason = "consumer message with attachments"
+                else:
+                    reason = "consumer message followed by opt-in"
             else:
                 reason = (
                     "two events: "


### PR DESCRIPTION
## Summary
- allow `_is_new_lead` to treat ATTACHMENT_GROUPING as a new lead
- add unit test for attachment grouping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68811d3e5bb8832d88c552df763463fa