### PR TITLE
Adjust new lead logic for second event

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -155,18 +155,11 @@ class WebhookView(APIView):
         elif len(events) == 2:
             first_user_type = events[0].get("user_type")
             second_event_type = events[1].get("event_type")
-            if (
-                first_user_type == "CONSUMER"
-                and second_event_type in {
-                    "CONSUMER_PHONE_NUMBER_OPT_IN_EVENT",
-                    "ATTACHMENT_GROUPING",
-                }
-            ):
+            if first_user_type == "CONSUMER" and second_event_type != "TEXT":
                 is_new = True
-                if second_event_type == "ATTACHMENT_GROUPING":
-                    reason = "consumer message with attachments"
-                else:
-                    reason = "consumer message followed by opt-in"
+                reason = (
+                    f"consumer message followed by {second_event_type}" if second_event_type else "consumer message followed by unknown event"
+                )
             else:
                 reason = (
                     "two events: "


### PR DESCRIPTION
## Summary
- change `_is_new_lead` to treat a lead as new when there are two events and the second event type is not `TEXT`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688278dde604832d9b2312a41312cbc5