### PR TITLE
Document new Yelp verification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ When a business account is authorized, the callback fetches
 `/businesses/{business_id}/lead_ids` for each connected business and stores the
 returned IDs in the local `ProcessedLead` table.
 
-During webhook processing the backend no longer queries Yelp. Instead it checks
-if the incoming `lead_id` exists in `ProcessedLead`. If not, the update is
-tagged as `"NEW_LEAD"` and the ID is saved so subsequent events are treated as
-already processed.
+During webhook processing the backend verifies unlisted leads by querying
+`https://api.yelp.com/v3/leads/{lead_id}/events` with `limit=2`. A lead is
+tagged as `"NEW_LEAD"` when Yelp returns only one consumer message or when a
+consumer message is immediately followed by an event whose type is anything
+other than `TEXT`. Once verified, the `lead_id` is saved so subsequent events are
+treated as already processed.
 
 Lead details and events are recorded for every lead even when automatic
 responses are disabled for a business.

--- a/backend/webhooks/tests/test_webhook_events.py
+++ b/backend/webhooks/tests/test_webhook_events.py
@@ -331,6 +331,34 @@ class LeadIdVerificationTests(TestCase):
     @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
     @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
     @patch.object(WebhookView, "handle_new_lead")
+    def test_mark_new_lead_with_blank_event_type(
+        self,
+        mock_new_lead,
+        mock_lead_token,
+        mock_business_token,
+        mock_get
+    ):
+        events_resp = type(
+            "E",
+            (),
+            {
+                "status_code": 200,
+                "json": lambda self: {
+                    "events": [
+                        {"id": "e0", "user_type": "CONSUMER"},
+                        {"id": "e1", "event_type": ""},
+                    ]
+                },
+            },
+        )()
+        mock_get.return_value = events_resp
+        self._post()
+        mock_new_lead.assert_called_once_with(self.lead_id)
+
+    @patch("webhooks.webhook_views.requests.get")
+    @patch("webhooks.webhook_views.get_valid_business_token", return_value="tok")
+    @patch("webhooks.webhook_views.get_token_for_lead", return_value="tok")
+    @patch.object(WebhookView, "handle_new_lead")
     def test_existing_lead_not_marked(
         self,
         mock_new_lead,


### PR DESCRIPTION
## Summary
- document verifying new leads via Yelp events
- test blank event type still marks new lead

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68829535ba78832d8541beca343aa2c1