### PR TITLE
Fix notification setting filtering

### DIFF
--- a/backend/webhooks/lead_views.py
+++ b/backend/webhooks/lead_views.py
@@ -289,7 +289,7 @@ class NotificationSettingListCreateView(generics.ListCreateAPIView):
         bid = self.request.query_params.get("business_id")
         qs = NotificationSetting.objects.all().order_by("id")
         if bid:
-            return qs.filter(Q(business__business_id=bid) | Q(business__isnull=True))
+            return qs.filter(business__business_id=bid)
         return qs.filter(business__isnull=True)
 
     def create(self, request, *args, **kwargs):
@@ -317,7 +317,7 @@ class NotificationSettingDetailView(generics.RetrieveUpdateDestroyAPIView):
         bid = self.request.query_params.get("business_id")
         qs = NotificationSetting.objects.all()
         if bid:
-            return qs.filter(Q(business__business_id=bid) | Q(business__isnull=True))
+            return qs.filter(business__business_id=bid)
         return qs.filter(business__isnull=True)
 
     def perform_update(self, serializer):

--- a/backend/webhooks/tests/test_notifications.py
+++ b/backend/webhooks/tests/test_notifications.py
@@ -1,0 +1,64 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from webhooks.lead_views import (
+    NotificationSettingListCreateView,
+    NotificationSettingDetailView,
+)
+from webhooks.models import YelpBusiness, NotificationSetting
+
+
+class NotificationSettingQuerysetTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.list_view = NotificationSettingListCreateView.as_view()
+        self.detail_view = NotificationSettingDetailView.as_view()
+        self.biz1 = YelpBusiness.objects.create(business_id="b1", name="Biz 1")
+        self.biz2 = YelpBusiness.objects.create(business_id="b2", name="Biz 2")
+        self.global_setting = NotificationSetting.objects.create(
+            business=None,
+            phone_number="111",
+            message_template="g",
+        )
+        self.biz1_setting = NotificationSetting.objects.create(
+            business=self.biz1,
+            phone_number="222",
+            message_template="b1",
+        )
+        self.biz2_setting = NotificationSetting.objects.create(
+            business=self.biz2,
+            phone_number="333",
+            message_template="b2",
+        )
+
+    def _get_list(self, bid=None):
+        url = "/notifications/"
+        if bid:
+            url += f"?business_id={bid}"
+        request = self.factory.get(url)
+        response = self.list_view(request)
+        response.render()
+        return response
+
+    def _get_detail(self, pk, bid=None):
+        url = f"/notifications/{pk}/"
+        if bid:
+            url += f"?business_id={bid}"
+        request = self.factory.get(url)
+        response = self.detail_view(request, pk=pk)
+        response.render()
+        return response
+
+    def test_list_filters_by_business_id(self):
+        resp = self._get_list("b1")
+        self.assertEqual(resp.status_code, 200)
+        ids = [item["id"] for item in resp.data]
+        self.assertEqual(ids, [self.biz1_setting.id])
+
+    def test_detail_with_wrong_business_id_returns_404(self):
+        resp = self._get_detail(self.biz1_setting.id, "b2")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_detail_with_correct_business_id_returns_object(self):
+        resp = self._get_detail(self.biz1_setting.id, "b1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["id"], self.biz1_setting.id)

--- a/frontend/src/Notifications.tsx
+++ b/frontend/src/Notifications.tsx
@@ -1,5 +1,10 @@
+import { useSearchParams } from 'react-router-dom';
 import NotificationSettings from './NotificationSettings';
 
-const Notifications = () => <NotificationSettings />;
+const Notifications = () => {
+  const [params] = useSearchParams();
+  const businessId = params.get('business_id') || undefined;
+  return <NotificationSettings businessId={businessId} />;
+};
 
 export default Notifications;


### PR DESCRIPTION
## Summary
- adjust notification settings queryset to not include global entries when a business is specified
- add regression tests for notification setting filtering
- load `business_id` from the URL on Notifications page so it matches Auto Response Settings

## Testing
- `python manage.py test webhooks.tests.test_notifications -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6882a9fbf7f8832d98b2c3703cd128d8