### PR TITLE
Add OpenAI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ VITE_API_BASE_URL=http://46.62.139.177:8000 npm run build
 
 If this variable is omitted, the app falls back to `http://46.62.139.177:8000/api`.
 
+## OpenAI integration
+
+AI-generated responses rely on the `openai` Python package. Install dependencies and
+provide your API key via the `OPENAI_API_KEY` environment variable:
+
+```bash
+export OPENAI_API_KEY=your-key
+pip install -r backend/requirements.txt
+```
+
+`webhooks.ai_service` will automatically use this key if present.
+
 ## Task log cleanup
 
 Old records in `CeleryTaskLog` can grow quickly. Remove entries older than 30 days

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,4 +21,5 @@ sentry-sdk[django]
 
 twilio
 python-decouple
+openai>=1.3,<2.0.0
 


### PR DESCRIPTION
## Summary
- include `openai` in backend requirements
- document the new requirement and how to set `OPENAI_API_KEY`

## Testing
- `pip install -r backend/requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68889812c06c832d94e96476501b478c