### PR TITLE
Prevent duplicate phone-found SMS

### DIFF
--- a/backend/webhooks/signals.py
+++ b/backend/webhooks/signals.py
@@ -48,10 +48,6 @@ def notify_new_lead(sender, instance: LeadDetail, created: bool, **kwargs):
             logger.info(f"[SMS-NOTIFICATION] Phone sources detected: {phone_sources}")
             logger.info(f"[SMS-NOTIFICATION] This handles the 'Phone Number Found' scenario (first time only)")
             
-            # Mark that we sent Phone Number Found SMS to prevent duplicates
-            instance.phone_sms_sent = True
-            instance.save(update_fields=['phone_sms_sent'])
-            logger.info(f"[SMS-NOTIFICATION] 🏃 Marked phone_sms_sent=True to prevent duplicate SMS")
         else:
             should_send_sms = False
             sms_trigger_reason = "Phone Number Found (SMS already sent)"
@@ -375,6 +371,12 @@ def notify_new_lead(sender, instance: LeadDetail, created: bool, **kwargs):
                 business_id=instance.business_id, 
                 purpose="notification"
             )
+            if 'Phone Number Found' in sms_trigger_reason and not getattr(instance, 'phone_sms_sent', False):
+                instance.phone_sms_sent = True
+                instance.save(update_fields=['phone_sms_sent'])
+                logger.info(
+                    f"[SMS-NOTIFICATION] 🏁 Marked phone_sms_sent=True for lead {instance.lead_id} after notification SMS"
+                )
             logger.info(f"[SMS-NOTIFICATION] ✅ SMS sent successfully!")
             logger.info(
                 f"[SMS-NOTIFICATION] SMS delivery details",

--- a/backend/webhooks/tests/test_phone_sms_duplicate.py
+++ b/backend/webhooks/tests/test_phone_sms_duplicate.py
@@ -1,0 +1,59 @@
+import os
+import django
+from django.test import TestCase
+from django.utils import timezone
+from unittest.mock import patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+from django.conf import settings
+settings.MIGRATION_MODULES = {"webhooks": None}
+django.setup()
+
+from webhooks.models import (
+    YelpBusiness,
+    ProcessedLead,
+    LeadDetail,
+    NotificationSetting,
+    AutoResponseSettings,
+)
+from webhooks.webhook_views import WebhookView
+
+
+class PhoneNumberFoundSMSTests(TestCase):
+    def setUp(self):
+        self.biz = YelpBusiness.objects.create(business_id="b1", name="Biz")
+        NotificationSetting.objects.create(
+            business=self.biz,
+            phone_number="+15555550123",
+            message_template="Test {lead_id}"
+        )
+        AutoResponseSettings.objects.create(
+            business=self.biz,
+            phone_available=True,
+            enabled=True,
+        )
+        ProcessedLead.objects.create(business_id="b1", lead_id="l1")
+        self.lead = LeadDetail.objects.create(
+            lead_id="l1",
+            business_id="b1",
+            conversation_id="c1",
+            time_created=timezone.now(),
+            project={},
+        )
+
+    def test_twilio_called_once_for_phone_number_found(self):
+        view = WebhookView()
+        with patch("webhooks.twilio_utils.send_sms", return_value="sid") as mock_send, \
+             patch("webhooks.signals.send_sms", new=mock_send), \
+             patch("webhooks.webhook_views.get_valid_business_token", side_effect=ValueError("no token")):
+            # Update lead with phone number to trigger signal
+            self.lead.phone_number = "+1234567890"
+            self.lead.phone_in_text = True
+            self.lead.phone_sms_sent = False
+            self.lead.save(update_fields=["phone_number", "phone_in_text", "phone_sms_sent"])
+
+            # Process auto-response which would attempt to send another SMS
+            view._process_auto_response(self.lead.lead_id, phone_opt_in=False, phone_available=True)
+
+            # Ensure send_sms was called only once (by the signal)
+            self.assertEqual(mock_send.call_count, 1)

--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -1352,6 +1352,12 @@ class WebhookView(APIView):
                             logger.info(f"[AUTO-RESPONSE] Selected setting: ID={business_settings_list[0].id}, phone={business_settings_list[0].phone_number}")
                         
                         for setting in business_settings_list:
+                            ld = LeadDetail.objects.filter(lead_id=lead_id).first()
+                            if phone_available and ld and getattr(ld, "phone_sms_sent", False):
+                                logger.info(
+                                    f"[AUTO-RESPONSE] 🚫 Skipping AutoResponseSettings SMS for lead {lead_id} - phone_sms_sent already True"
+                                )
+                                continue
                             try:
                                 # Format message for AutoResponseSettings SMS
                                 business_name = pl.business.name if hasattr(pl, 'business') and pl.business else pl.business_id
@@ -1382,6 +1388,12 @@ class WebhookView(APIView):
                                     business_id=pl.business_id,
                                     purpose="auto_response"
                                 )
+                                if phone_available and ld and not getattr(ld, "phone_sms_sent", False):
+                                    ld.phone_sms_sent = True
+                                    ld.save(update_fields=["phone_sms_sent"])
+                                    logger.info(
+                                        f"[AUTO-RESPONSE] 🏁 Marked phone_sms_sent=True for lead {lead_id} after AutoResponse SMS"
+                                    )
                                 
                                 logger.info(f"[AUTO-RESPONSE] ✅ AutoResponseSettings SMS sent successfully!")
                                 logger.info(f"[AUTO-RESPONSE] - SID: {sid}")


### PR DESCRIPTION
## Summary
- avoid sending auto-response SMS twice by checking `phone_sms_sent`
- mark `phone_sms_sent` after successful notification signal send
- cover Phone Number Found scenario with test to ensure Twilio client called once

## Testing
- `pytest backend/webhooks/tests/test_phone_sms_duplicate.py -q` *(fails: django.db.utils.OperationalError: no such table: webhooks_yelpbusiness)*

------
https://chatgpt.com/codex/tasks/task_e_6899ee6796cc832d816237bdf852ef7b