### PR TITLE
Preserve phone opt-in from events

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -1803,6 +1803,13 @@ class WebhookView(APIView):
         display_name = d.get("user", {}).get("display_name", "")
         first_name = display_name.split()[0] if display_name else ""
 
+        existing_opt = (
+            LeadDetail.objects.filter(lead_id=lead_id)
+            .values_list("phone_opt_in", flat=True)
+            .first()
+            or False
+        )
+
         detail_data = {
             "lead_id": lead_id,
             "business_id": d.get("business_id"),
@@ -1813,7 +1820,7 @@ class WebhookView(APIView):
             "last_event_time": last_time,
             "user_display_name": first_name,
             "phone_number": phone_number,
-            "phone_opt_in": d.get("phone_opt_in", False),
+            "phone_opt_in": phone_opt_in or d.get("phone_opt_in", existing_opt),
             "project": {
                 "survey_answers": survey_list,
                 "location": raw_proj.get("location", {}),


### PR DESCRIPTION
## Summary
- retain existing phone opt-in state when processing auto-response details

## Testing
- `pip install pytest-django` *(fails: Could not find a version that satisfies the requirement pytest-django)*
- `TWILIO_ACCOUNT_SID=test TWILIO_AUTH_TOKEN=test TWILIO_PHONE_NUMBER=123 DJANGO_SETTINGS_MODULE=config.settings pytest webhooks/tests/test_webhook_events.py::TestPhoneOptIn -q` *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_689d0af93adc832d9f0ab0f91ade3281