### PR TITLE
Handle missing Yelp detail gracefully

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -1756,8 +1756,9 @@ class WebhookView(APIView):
                 f"[AUTO-RESPONSE] DETAIL ERROR lead={lead_id}, business_id={pl.business_id if pl else 'N/A'}, "
                 f"token_source={source}, token={token[:20]}..., status={resp.status_code}, body={resp.text}"
             )
-            return
-        d = resp.json()
+            d = {}
+        else:
+            d = resp.json()
 
         last_time = None
         ev_resp = requests.get(
@@ -1812,11 +1813,11 @@ class WebhookView(APIView):
 
         detail_data = {
             "lead_id": lead_id,
-            "business_id": d.get("business_id"),
-            "conversation_id": d.get("conversation_id"),
+            "business_id": d.get("business_id") or (pl.business_id if pl else None),
+            "conversation_id": d.get("conversation_id", ""),
             "temporary_email_address": d.get("temporary_email_address"),
             "temporary_email_address_expiry": d.get("temporary_email_address_expiry"),
-            "time_created": d.get("time_created"),
+            "time_created": d.get("time_created") or timezone.now(),
             "last_event_time": last_time,
             "user_display_name": first_name,
             "phone_number": phone_number,
@@ -2062,6 +2063,7 @@ class WebhookView(APIView):
         now = timezone.now()
         tz_name = business.time_zone if business else None
         within_hours = True
+        days_setting = None
         
         logger.info(f"[AUTO-RESPONSE] Business hours calculation:")
         logger.info(f"[AUTO-RESPONSE] - Current UTC time: {now}")


### PR DESCRIPTION
## Summary
- Continue auto-response scheduling even if Yelp lead detail API call fails
- Guard against missing detail data when building LeadDetail records
- Test 404 detail response still schedules an auto-response

## Testing
- `python - <<'PY'
import os, sys, logging
sys.path.append('backend')
os.environ['DJANGO_SETTINGS_MODULE'] = 'config.settings'
os.environ['TWILIO_ACCOUNT_SID'] = ''
os.environ['TWILIO_AUTH_TOKEN'] = ''
os.environ['TWILIO_PHONE_NUMBER'] = ''
logging.disable(logging.CRITICAL)
import django
django.setup()
from django.conf import settings
settings.MIGRATION_MODULES = {'webhooks': None}
from django.core.management import call_command
call_command('test', 'webhooks.tests.test_webhook_events.AutoResponse404DetailTests.test_detail_404_still_schedules_auto_response', verbosity=1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e5de17a94832d8b690011122b9529