### PR TITLE
Preserve phone opt-in flag when updating lead details

### DIFF
--- a/backend/webhooks/webhook_views.py
+++ b/backend/webhooks/webhook_views.py
@@ -1823,6 +1823,11 @@ class WebhookView(APIView):
         display_name = d.get("user", {}).get("display_name", "")
         first_name = display_name.split()[0] if display_name else ""
 
+        existing_ld = LeadDetail.objects.filter(lead_id=lead_id).first()
+        phone_opt_in_value = phone_opt_in or d.get("phone_opt_in", False)
+        if existing_ld and existing_ld.phone_opt_in:
+            phone_opt_in_value = True
+
         detail_data = {
             "lead_id": lead_id,
             "business_id": d.get("business_id"),
@@ -1833,7 +1838,7 @@ class WebhookView(APIView):
             "last_event_time": last_time,
             "user_display_name": first_name,
             "phone_number": phone_number,
-            "phone_opt_in": d.get("phone_opt_in", False),
+            "phone_opt_in": phone_opt_in_value,
             "project": {
                 "survey_answers": survey_list,
                 "location": raw_proj.get("location", {}),


### PR DESCRIPTION
## Summary
- Ensure `_process_auto_response` keeps existing `phone_opt_in` true and leverages function argument or Yelp data when creating `detail_data`
- Add regression test verifying that subsequent updates do not reset `phone_opt_in`

## Testing
- `python -m py_compile backend/webhooks/webhook_views.py backend/webhooks/tests/test_webhook_events.py`
- `TWILIO_ACCOUNT_SID=1 TWILIO_AUTH_TOKEN=1 TWILIO_PHONE_NUMBER=1 python backend/manage.py test webhooks.tests.test_webhook_events.PhoneOptInPersistenceTests.test_phone_opt_in_not_overwritten -v 2` *(fails: table "webhooks_timebasedgreeting" already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68b7589b93b8832d8b81df2d9ef87a77